### PR TITLE
[pycodestyle] Fix violations

### DIFF
--- a/skt.py
+++ b/skt.py
@@ -1,17 +1,18 @@
 #!/usr/bin/python2
 
-# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted material
-# is made available to anyone wishing to use, modify, copy, or
+# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2 or later.
 #
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 import ConfigParser
 import argparse
@@ -24,11 +25,15 @@ import os
 import shutil
 import sys
 import time
-import skt, skt.runner, skt.publisher, skt.reporter
+import skt.publisher
+import skt.reporter
+import skt.runner
+import skt
 
 DEFAULTRC = "~/.sktrc"
 logger = logging.getLogger()
 retcode = 0
+
 
 def save_state(cfg, state):
     for (key, val) in state.iteritems():
@@ -42,7 +47,7 @@ def save_state(cfg, state):
         config.add_section("state")
 
     for (key, val) in state.iteritems():
-        if val != None:
+        if val is not None:
             logging.debug("state: %s -> %s", key, val)
             config.set('state', key, val)
 
@@ -50,6 +55,7 @@ def save_state(cfg, state):
     # usefulness, because tilde is a valid path character.
     with open(os.path.expanduser(cfg.get('rc')), 'w') as fp:
         config.write(fp)
+
 
 def junit(func):
     """
@@ -77,7 +83,7 @@ def junit(func):
     """
     def wrapper(cfg):
         global retcode
-        if cfg.get('junit') != None:
+        if cfg.get('junit') is not None:
             tstart = time.time()
             tc = junit_xml.TestCase(func.__name__, classname="skt")
 
@@ -104,19 +110,20 @@ def junit(func):
 def cmd_merge(cfg):
     global retcode
     utypes = []
-    ktree = skt.ktree(cfg.get('baserepo'), ref=cfg.get('ref'),
-                              wdir=cfg.get('workdir'))
+    ktree = skt.ktree(cfg.get('baserepo'),
+                      ref=cfg.get('ref'),
+                      wdir=cfg.get('workdir'))
     bhead = ktree.checkout()
     commitdate = ktree.get_commit_date(bhead)
-    save_state(cfg, {'baserepo' : cfg.get('baserepo'),
-                     'basehead' : bhead,
-                     'commitdate' : commitdate})
+    save_state(cfg, {'baserepo': cfg.get('baserepo'),
+                     'basehead': bhead,
+                     'commitdate': commitdate})
 
     try:
         idx = 0
         for mb in cfg.get('merge_ref'):
-            save_state(cfg, {'meregerepo_%02d' % idx : mb[0],
-                             'mergehead_%02d' % idx : head})
+            save_state(cfg, {'meregerepo_%02d' % idx: mb[0],
+                             'mergehead_%02d' % idx: head})
             (retcode, head) = ktree.merge_git_ref(*mb)
 
             utypes.append("[git]")
@@ -124,23 +131,23 @@ def cmd_merge(cfg):
             if retcode != 0:
                 return
 
-        if cfg.get('patchlist') != None:
+        if cfg.get('patchlist') is not None:
             utypes.append("[local patch]")
             idx = 0
             for patch in cfg.get('patchlist'):
-                save_state(cfg, {'localpatch_%02d' % idx : patch})
+                save_state(cfg, {'localpatch_%02d' % idx: patch})
                 ktree.merge_patch_file(patch)
                 idx += 1
 
-        if cfg.get('pw') != None:
+        if cfg.get('pw') is not None:
             utypes.append("[patchwork]")
             idx = 0
             for patch in cfg.get('pw'):
-                save_state(cfg, {'patchwork_%02d' % idx : patch})
+                save_state(cfg, {'patchwork_%02d' % idx: patch})
                 ktree.merge_patchwork_patch(patch)
                 idx += 1
     except Exception as e:
-        save_state(cfg, {'mergelog' : ktree.mergelog})
+        save_state(cfg, {'mergelog': ktree.mergelog})
         raise e
 
     uid = "[baseline]"
@@ -151,14 +158,16 @@ def cmd_merge(cfg):
     buildinfo = ktree.dumpinfo()
     buildhead = ktree.get_commit()
 
-    save_state(cfg, {'workdir'   : kpath,
-                     'buildinfo' : buildinfo,
-                     'buildhead' : buildhead,
-                     'uid'       : uid})
+    save_state(cfg, {'workdir': kpath,
+                     'buildinfo': buildinfo,
+                     'buildhead': buildhead,
+                     'uid': uid})
+
 
 @junit
 def cmd_build(cfg):
-    tstamp = datetime.datetime.strftime(datetime.datetime.now(), "%Y%m%d%H%M%S")
+    tstamp = datetime.datetime.strftime(datetime.datetime.now(),
+                                        "%Y%m%d%H%M%S")
 
     builder = skt.kbuilder(cfg.get('workdir'), cfg.get('baseconfig'),
                            cfg.get('cfgtype'), cfg.get('makeopts'))
@@ -166,10 +175,10 @@ def cmd_build(cfg):
     try:
         tgz = builder.mktgz(cfg.get('wipe'))
     except Exception as e:
-        save_state(cfg, {'buildlog' : builder.buildlog})
+        save_state(cfg, {'buildlog': builder.buildlog})
         raise e
 
-    if cfg.get('buildhead') != None:
+    if cfg.get('buildhead') is not None:
         ttgz = "%s.tar.gz" % cfg.get('buildhead')
     else:
         ttgz = addtstamp(tgz, tstamp)
@@ -177,8 +186,8 @@ def cmd_build(cfg):
     logging.info("tarball path: %s", ttgz)
 
     tbuildinfo = None
-    if cfg.get('buildinfo') != None:
-        if cfg.get('buildhead') != None:
+    if cfg.get('buildinfo') is not None:
+        if cfg.get('buildhead') is not None:
             tbuildinfo = "%s.csv" % cfg.get('buildhead')
         else:
             tbuildinfo = addtstamp(cfg.get('buildinfo'), tstamp)
@@ -189,10 +198,11 @@ def cmd_build(cfg):
 
     krelease = builder.getrelease()
 
-    save_state(cfg, {'tarpkg'    : ttgz,
-                     'buildinfo' : tbuildinfo,
-                     'buildconf' : tconfig,
-                     'krelease'  : krelease})
+    save_state(cfg, {'tarpkg': ttgz,
+                     'buildinfo': tbuildinfo,
+                     'buildconf': tconfig,
+                     'krelease': krelease})
+
 
 @junit
 def cmd_publish(cfg):
@@ -202,28 +212,29 @@ def cmd_publish(cfg):
     url = publisher.publish(cfg.get('tarpkg'))
     logging.info("published url: %s", url)
 
-    if cfg.get('buildinfo') != None:
+    if cfg.get('buildinfo') is not None:
         infourl = publisher.publish(cfg.get('buildinfo'))
 
-    if cfg.get('buildconf') != None:
+    if cfg.get('buildconf') is not None:
         cfgurl = publisher.publish(cfg.get('buildconf'))
 
-    save_state(cfg, {'buildurl' : url,
-                     'cfgurl'   : cfgurl,
-                     'infourl'  : infourl})
+    save_state(cfg, {'buildurl': url,
+                     'cfgurl': cfgurl,
+                     'infourl': infourl})
+
 
 @junit
 def cmd_run(cfg):
     global retcode
     runner = skt.runner.getrunner(*cfg.get('runner'))
     retcode = runner.run(cfg.get('buildurl'), cfg.get('krelease'),
-                         cfg.get('wait'), uid = cfg.get('uid'))
+                         cfg.get('wait'), uid=cfg.get('uid'))
 
     idx = 0
     for job in runner.jobs:
-        if cfg.get('wait') and cfg.get('junit') != None:
+        if cfg.get('wait') and cfg.get('junit') is not None:
             runner.dumpjunitresults(job, cfg.get('junit'))
-        save_state(cfg, {'jobid_%s' % (idx) : job})
+        save_state(cfg, {'jobid_%s' % (idx): job})
         idx += 1
 
     cfg['jobs'] = runner.jobs
@@ -236,27 +247,29 @@ def cmd_run(cfg):
         baseurl = publisher.geturl("%s.tar.gz" % cfg.get('basehead'))
         basehost = runner.get_mfhost()
         baseres = baserunner.run(baseurl, cfg.get('krelease'), cfg.get('wait'),
-                                 host = basehost, uid = "baseline check",
-                                 reschedule = False)
-        save_state(cfg, {'baseretcode' : baseres})
+                                 host=basehost, uid="baseline check",
+                                 reschedule=False)
+        save_state(cfg, {'baseretcode': baseres})
 
         # If baseline also fails - assume pass
         if baseres != 0:
             retcode = 0
 
-    save_state(cfg, {'retcode' : retcode})
+    save_state(cfg, {'retcode': retcode})
 
-    if retcode != 0 and cfg.get('bisect') == True:
+    if retcode != 0 and cfg.get('bisect'):
         cfg['commitbad'] = cfg.get('mergehead')
         cmd_bisect(cfg)
 
+
 def cmd_report(cfg):
-    if cfg.get("reporter") == None:
+    if cfg.get("reporter") is None:
         return
 
-    cfg['reporter'][1].update({'cfg' : cfg})
+    cfg['reporter'][1].update({'cfg': cfg})
     reporter = skt.reporter.getreporter(*cfg.get('reporter'))
     reporter.report()
+
 
 def cmd_cleanup(cfg):
     config = cfg.get('_parser')
@@ -267,16 +280,16 @@ def cmd_cleanup(cfg):
         with open(os.path.expanduser(cfg.get('rc')), 'w') as fp:
             config.write(fp)
 
-    if cfg.get('buildinfo') != None:
+    if cfg.get('buildinfo') is not None:
         try:
             os.unlink(cfg.get('buildinfo'))
-        except:
+        except OSError:
             pass
 
-    if cfg.get('tarpkg') != None:
+    if cfg.get('tarpkg') is not None:
         try:
             os.unlink(cfg.get('tarpkg'))
-        except:
+        except OSError:
             pass
 
     if cfg.get('wipe'):
@@ -284,22 +297,27 @@ def cmd_cleanup(cfg):
         # usefulness, because tilde is a valid path character.
         shutil.rmtree(os.path.expanduser(cfg.get('workdir')))
 
+
 def cmd_all(cfg):
     cmd_merge(cfg)
     cmd_build(cfg)
     cmd_publish(cfg)
     cmd_run(cfg)
-    if cfg.get('wait') == True:
+    if cfg.get('wait'):
         cmd_report(cfg)
     cmd_cleanup(cfg)
+
 
 @junit
 def cmd_bisect(cfg):
     if len(cfg.get('merge_ref')) != 1:
-        raise Exception("Bisecting currently works only with exactly one mergeref")
+        raise Exception(
+            "Bisecting currently works only with exactly one mergeref"
+        )
 
-    ktree = skt.ktree(cfg.get('baserepo'), ref=cfg.get('commitgood'),
-                              wdir=cfg.get('workdir'))
+    ktree = skt.ktree(cfg.get('baserepo'),
+                      ref=cfg.get('commitgood'),
+                      wdir=cfg.get('workdir'))
     head = ktree.checkout()
 
     cfg['workdir'] = ktree.getpath()
@@ -313,9 +331,9 @@ def cmd_bisect(cfg):
     runner = skt.runner.getrunner(*cfg.get('runner'))
 
     retcode = runner.run(cfg.get('buildurl'), cfg.get('krelease'),
-                         wait = True, host = cfg.get('host'),
-                         uid = "[bisect] [good %s]" % head,
-                         reschedule = False)
+                         wait=True, host=cfg.get('host'),
+                         uid="[bisect] [good %s]" % head,
+                         reschedule=False)
 
     cfg['host'] = runner.gethost()
 
@@ -333,17 +351,19 @@ def cmd_bisect(cfg):
         cmd_publish(cfg)
         os.unlink(cfg.get('tarpkg'))
         retcode = runner.run(cfg.get('buildurl'), cfg.get('krelease'),
-                             wait = True, host = cfg.get('host'),
-                             uid = "[bisect] [%s]" % binfo,
-                             reschedule = False)
+                             wait=True, host=cfg.get('host'),
+                             uid="[bisect] [%s]" % binfo,
+                             reschedule=False)
 
         (ret, binfo) = ktree.bisect_iter(retcode)
 
     cmd_cleanup(cfg)
 
+
 def addtstamp(path, tstamp):
     return os.path.join(os.path.dirname(path),
                         "%s-%s" % (tstamp, os.path.basename(path)))
+
 
 def setup_logging(verbose):
     """
@@ -366,9 +386,12 @@ def setup_parser():
     parser = argparse.ArgumentParser()
 
     parser.add_argument("-d", "--workdir", type=str, help="Path to work dir")
-    parser.add_argument("-w", "--wipe", help="Clean build (make mrproper before building), remove workdir when finished",
+    parser.add_argument("-w", "--wipe",
+                        help="Clean build (make mrproper before building), "
+                        "remove workdir when finished",
                         action="store_true", default=False)
-    parser.add_argument("--junit", help="Path to dir to store junit results in")
+    parser.add_argument("--junit",
+                        help="Path to dir to store junit results in")
     parser.add_argument("-v", "--verbose", help="Increase verbosity level",
                         action="count", default=0)
     parser.add_argument("--rc", help="Path to rc file", default=DEFAULTRC)
@@ -376,59 +399,79 @@ def setup_parser():
     #       state saving aborts. It's better to save state separately.
     #       It also breaks separation of concerns, as in principle skt doesn't
     #       need to modify its own configuration otherwise.
-    parser.add_argument("--state", help="Save/read state from 'state' section of rc file",
-                        action="store_true", default=False)
+    parser.add_argument("--state", help="Save/read state from 'state' section "
+                        "of rc file", action="store_true", default=False)
 
     subparsers = parser.add_subparsers()
 
     parser_merge = subparsers.add_parser("merge", add_help=False)
-    parser_merge.add_argument("-b", "--baserepo", type=str, help="Base repo URL")
-    parser_merge.add_argument("--ref", type=str, help="Base repo ref (default: master")
-    parser_merge.add_argument("--patchlist", type=str, nargs="+", help="List of patch paths to apply")
-    parser_merge.add_argument("--pw", type=str, nargs="+", help="Patchwork urls")
-    parser_merge.add_argument("-m", "--merge-ref", nargs="+", help="Merge ref format: 'url [ref]'",
+    parser_merge.add_argument("-b", "--baserepo", type=str,
+                              help="Base repo URL")
+    parser_merge.add_argument("--ref", type=str,
+                              help="Base repo ref (default: master")
+    parser_merge.add_argument("--patchlist", type=str, nargs="+",
+                              help="List of patch paths to apply")
+    parser_merge.add_argument("--pw", type=str, nargs="+",
+                              help="Patchwork urls")
+    parser_merge.add_argument("-m", "--merge-ref", nargs="+",
+                              help="Merge ref format: 'url [ref]'",
                               action="append")
 
     parser_build = subparsers.add_parser("build", add_help=False)
-    parser_build.add_argument("-c", "--baseconfig", type=str, help="Path to kernel config to use")
-    parser_build.add_argument("--cfgtype", type=str, help="How to process default config (default: olddefconfig)")
-    parser_build.add_argument("--makeopts", type=str, help="Additional options to pass to make")
+    parser_build.add_argument("-c", "--baseconfig", type=str,
+                              help="Path to kernel config to use")
+    parser_build.add_argument("--cfgtype", type=str, help="How to process "
+                              "default config (default: olddefconfig)")
+    parser_build.add_argument("--makeopts", type=str,
+                              help="Additional options to pass to make")
 
     parser_publish = subparsers.add_parser("publish", add_help=False)
-    parser_publish.add_argument("-p", "--publisher", type=str, nargs=3, help="Publisher config string in 'type destination baseurl' format")
-    parser_publish.add_argument("--tarpkg", type=str, help="Path to tar pkg to publish")
-    parser_publish.add_argument("--buildinfo", type=str, help="Path to accompanying buildinfo")
+    parser_publish.add_argument("-p", "--publisher", type=str, nargs=3,
+                                help="Publisher config string in 'type "
+                                "destination baseurl' format")
+    parser_publish.add_argument("--tarpkg", type=str,
+                                help="Path to tar pkg to publish")
+    parser_publish.add_argument("--buildinfo", type=str,
+                                help="Path to accompanying buildinfo")
 
     parser_run = subparsers.add_parser("run", add_help=False)
-    parser_run.add_argument("-r", "--runner", nargs=2, type=str, help="Runner config in 'type \"{'key' : 'val', ...}\"' format")
+    parser_run.add_argument("-r", "--runner", nargs=2, type=str,
+                            help="Runner config in 'type \"{'key' : 'val', "
+                            "...}\"' format")
     parser_run.add_argument("--buildurl", type=str, help="Build tarpkg url")
-    parser_run.add_argument("--krelease", type=str, help="Kernel release version of the build")
-    parser_run.add_argument("--wait", help="Do not exit until tests are finished",
-                            action="store_true", default=False)
-    parser_run.add_argument("--bisect", help="Try to bisect the failure if any.  (Implies --wait)",
+    parser_run.add_argument("--krelease", type=str,
+                            help="Kernel release version of the build")
+    parser_run.add_argument("--wait", action="store_true", default=False,
+                            help="Do not exit until tests are finished")
+    parser_run.add_argument("--bisect", help="Try to bisect the failure if "
+                            "any.  (Implies --wait)",
                             action="store_true", default=False)
 
     parser_report = subparsers.add_parser("report", add_help=False)
-    parser_report.add_argument("--reporter", nargs=2, type=str, help="Reporter config in 'type \"{'key' : 'val', ...}\"' format")
+    parser_report.add_argument("--reporter", nargs=2, type=str,
+                               help="Reporter config in 'type \"{'key' : "
+                               "'val', ...}\"' format")
     parser_report.set_defaults(func=cmd_report)
     parser_report.set_defaults(_name="report")
 
     parser_cleanup = subparsers.add_parser("cleanup", add_help=False)
 
-    parser_all = subparsers.add_parser("all", parents = [parser_merge,
-        parser_build, parser_publish, parser_run, parser_report,
-        parser_cleanup])
+    parser_all = subparsers.add_parser(
+        "all",
+        parents=[parser_merge, parser_build, parser_publish, parser_run,
+                 parser_report, parser_cleanup]
+    )
 
     parser_merge.add_argument("-h", "--help", help="Merge sub-command help",
                               action="help")
     parser_build.add_argument("-h", "--help", help="Build sub-command help",
                               action="help")
-    parser_publish.add_argument("-h", "--help", help="Publish sub-command help",
-                              action="help")
+    parser_publish.add_argument("-h", "--help", action="help",
+                                help="Publish sub-command help")
     parser_run.add_argument("-h", "--help", help="Run sub-command help",
-                              action="help")
+                            action="help")
     parser_report.add_argument("-h", "--help", help="Report sub-command help",
-                              action="help")
+                               action="help")
 
     parser_merge.set_defaults(func=cmd_merge)
     parser_merge.set_defaults(_name="merge")
@@ -444,13 +487,17 @@ def setup_parser():
     parser_all.set_defaults(_name="all")
 
     parser_bisect = subparsers.add_parser("bisect", add_help=True)
-    parser_bisect.add_argument("commitbad", type=str, help="Bad commit for bisect")
-    parser_bisect.add_argument("--commitgood", type=str, help="Good commit for bisect. Default's to baserepo's HEAD")
-    parser_bisect.add_argument("--host", type=str, help="If needs to be bisected on specific host")
+    parser_bisect.add_argument("commitbad", type=str,
+                               help="Bad commit for bisect")
+    parser_bisect.add_argument("--commitgood", type=str, help="Good commit "
+                               "for bisect. Default's to baserepo's HEAD")
+    parser_bisect.add_argument("--host", type=str, help="If needs to be "
+                               "bisected on specific host")
     parser_bisect.set_defaults(func=cmd_bisect)
     parser_bisect.set_defaults(_name="bisect")
 
     return parser
+
 
 def load_config(args):
     """
@@ -473,7 +520,7 @@ def load_config(args):
     # section values.
     if cfg.get('state') and config.has_section('state'):
         for (name, value) in config.items('state'):
-            if name not in cfg or cfg.get(name) == None:
+            if name not in cfg or cfg.get(name) is None:
                 if name.startswith("jobid_"):
                     if "jobs" not in cfg:
                         cfg["jobs"] = set()
@@ -498,40 +545,39 @@ def load_config(args):
 
     if config.has_section('config'):
         for (name, value) in config.items('config'):
-            if name not in cfg or cfg.get(name) == None:
+            if name not in cfg or cfg.get(name) is None:
                 cfg[name] = value
 
     if config.has_section('publisher') and ('publisher' not in cfg or
-                                            cfg.get('publisher') == None):
+                                            cfg.get('publisher') is None):
         cfg['publisher'] = [config.get('publisher', 'type'),
                             config.get('publisher', 'destination'),
                             config.get('publisher', 'baseurl')]
 
     if config.has_section('runner') and ('runner' not in cfg or
-                                            cfg.get('runner') == None):
+                                         cfg.get('runner') is None):
         rcfg = {}
         for (key, val) in config.items('runner'):
             if key == 'type':
                 continue
             rcfg[key] = val
         cfg['runner'] = [config.get('runner', 'type'), rcfg]
-    elif 'runner' in cfg and cfg.get('runner') != None:
+    elif 'runner' in cfg and cfg.get('runner') is not None:
         cfg['runner'] = [cfg.get('runner')[0],
                          ast.literal_eval(cfg.get('runner')[1])]
 
-    if config.has_section('reporter') and (cfg.get('reporter') == None):
+    if config.has_section('reporter') and (cfg.get('reporter') is None):
         rcfg = {}
         for (key, val) in config.items('reporter'):
             if key == 'type':
                 continue
             rcfg[key] = val
         cfg['reporter'] = [config.get('reporter', 'type'), rcfg]
-    elif 'reporter' in cfg and cfg.get('reporter') != None:
+    elif 'reporter' in cfg and cfg.get('reporter') is not None:
         cfg['reporter'] = [cfg.get('reporter')[0],
-                         ast.literal_eval(cfg.get('reporter')[1])]
+                           ast.literal_eval(cfg.get('reporter')[1])]
 
-
-    if 'merge_ref' not in cfg or cfg.get('merge_ref') == None:
+    if 'merge_ref' not in cfg or cfg.get('merge_ref') is None:
         cfg['merge_ref'] = []
 
     for section in config.sections():
@@ -557,17 +603,18 @@ def main():
     cfg = load_config(args)
 
     args.func(cfg)
-    if cfg.get('junit') != None:
+    if cfg.get('junit') is not None:
         ts = junit_xml.TestSuite("skt", cfg.get('_testcases'))
         with open("%s/%s.xml" % (cfg.get('junit'), args._name), 'w') as fp:
             junit_xml.TestSuite.to_file(fp, [ts])
 
     sys.exit(retcode)
 
+
 if __name__ == '__main__':
     try:
         main()
     except KeyboardInterrupt:
-        #cleanup??
+        # cleanup??
         print("\nExited at user request.")
         sys.exit(1)

--- a/skt/publisher.py
+++ b/skt/publisher.py
@@ -1,20 +1,22 @@
-# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted material
-# is made available to anyone wishing to use, modify, copy, or
+# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2 or later.
 #
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 import logging
 import os
 import shutil
 import subprocess
+
 
 class publisher(object):
     """An abstract result publisher"""
@@ -51,6 +53,7 @@ class publisher(object):
 
     # TODO Define abstract "publish" method.
 
+
 class cppublisher(publisher):
     TYPE = 'cp'
 
@@ -60,14 +63,18 @@ class cppublisher(publisher):
         shutil.copy(os.path.expanduser(source), self.destination)
         return self.geturl(source)
 
+
 class scppublisher(publisher):
     TYPE = 'scp'
 
     def publish(self, source):
         # FIXME Move expansion up the call stack, as this limits the class
         # usefulness, because tilde is a valid path character.
-        subprocess.check_call(["scp", os.path.expanduser(source), self.destination])
+        subprocess.check_call(["scp",
+                               os.path.expanduser(source),
+                               self.destination])
         return self.geturl(source)
+
 
 def getpublisher(ptype, parg, pburl):
     """

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -1,15 +1,16 @@
-# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted material
-# is made available to anyone wishing to use, modify, copy, or
+# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General
 # Public License v.2 or later.
 #
-# This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A  PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+# along with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 import bkr.client
 from email.mime.application import MIMEApplication
@@ -28,6 +29,7 @@ import xmlrpclib
 import skt
 import skt.runner
 
+
 def gzipdata(data):
     """
     Compress a string with gzip.
@@ -39,45 +41,45 @@ def gzipdata(data):
         String containing gzip-compressed data.
     """
     tstr = StringIO.StringIO()
-    with gzip.GzipFile(fileobj = tstr, mode="w") as f:
+    with gzip.GzipFile(fileobj=tstr, mode="w") as f:
         f.write(data)
     return tstr.getvalue()
+
 
 class consolelog(object):
     """Console log parser"""
 
     # List of regular expression strings matching
     # lines beginning an oops or a call trace output
-    oopsmsg = [
-	"general protection fault:",
-	"BUG:",
-	"kernel BUG at",
-	"do_IRQ: stack overflow:",
-	"RTNL: assertion failed",
-	"Eeek! page_mapcount\(page\) went negative!",
-	"near stack overflow \(cur:",
-	"double fault:",
-	"Badness at",
-	"NETDEV WATCHDOG",
-	"WARNING: at",
-	"appears to be on the same physical disk",
-	"Unable to handle kernel",
-	"sysctl table check failed",
-	"------------\[ cut here \]------------",
-	"list_del corruption\.",
-	"list_add corruption\.",
-	"NMI watchdog: BUG: soft lockup",
-	"irq [0-9]+: nobody cared",
-	"INFO: task .* blocked for more than [0-9]+ seconds",
-	"vmwrite error: reg ",
-	"page allocation failure: order:",
-	"page allocation stalls for.*order:.*mode:",
-	"INFO: rcu_sched self-detected stall on CPU",
-	"INFO: rcu_sched detected stalls on CPUs/tasks:",
-	"NMI watchdog: Watchdog detected hard LOCKUP",
-	"Kernel panic - not syncing: ",
-	"Oops: Unrecoverable TM Unavailable Exception",
-    ]
+    oopsmsg = ["general protection fault:",
+               "BUG:",
+               "kernel BUG at",
+               "do_IRQ: stack overflow:",
+               "RTNL: assertion failed",
+               "Eeek! page_mapcount\(page\) went negative!",
+               "near stack overflow \(cur:",
+               "double fault:",
+               "Badness at",
+               "NETDEV WATCHDOG",
+               "WARNING: at",
+               "appears to be on the same physical disk",
+               "Unable to handle kernel",
+               "sysctl table check failed",
+               "------------\[ cut here \]------------",
+               "list_del corruption\.",
+               "list_add corruption\.",
+               "NMI watchdog: BUG: soft lockup",
+               "irq [0-9]+: nobody cared",
+               "INFO: task .* blocked for more than [0-9]+ seconds",
+               "vmwrite error: reg ",
+               "page allocation failure: order:",
+               "page allocation stalls for.*order:.*mode:",
+               "INFO: rcu_sched self-detected stall on CPU",
+               "INFO: rcu_sched detected stalls on CPUs/tasks:",
+               "NMI watchdog: Watchdog detected hard LOCKUP",
+               "Kernel panic - not syncing: ",
+               "Oops: Unrecoverable TM Unavailable Exception"
+               ]
 
     # List of regular expression strings matching
     # lines appearing in a call trace output
@@ -120,7 +122,7 @@ class consolelog(object):
         self.kver = kver
         self.data = None
         self.oopspattern = re.compile("(%s)" % "|".join(self.oopsmsg))
-        self.ctvpattern  = re.compile("(%s)" % "|".join(self.ctvalid))
+        self.ctvpattern = re.compile("(%s)" % "|".join(self.ctvalid))
         self.eendpattern = re.compile("(%s)" % "|".join(self.expend))
 
     def fetchdata(self):
@@ -132,10 +134,10 @@ class consolelog(object):
 
         self.data = []
         for line in r.text.split('\n'):
-            if tkernel == False and line.find("Linux version %s" % self.kver) != -1:
+            if not tkernel and line.find("Linux version %s" % self.kver) != -1:
                 tkernel = True
 
-            if tkernel == True:
+            if tkernel:
                 self.data.append(line.encode('utf-8'))
 
     def getfulllog(self):
@@ -143,7 +145,7 @@ class consolelog(object):
         Get the gzip-compressed text of the kernel console log.
         Can only be called after fetchdata().
         """
-	return gzipdata("\n".join(self.data))
+        return gzipdata("\n".join(self.data))
 
     def gettraces(self):
         """
@@ -156,7 +158,7 @@ class consolelog(object):
         result = []
         # FIXME Remove implicit fetching as it can hide bugs, as is the case
         # right now in reporter.getjobresults()
-        if self.data == None:
+        if self.data is None:
             self.fetchdata()
 
         insplat = False
@@ -171,7 +173,7 @@ class consolelog(object):
                 inct = True
 
             if insplat and ((inct and not self.ctvpattern.search(line)) or
-                    self.eendpattern.search(line)):
+                            self.eendpattern.search(line)):
                 tmpdata.append(line)
                 result.append("\n".join(tmpdata))
                 tmpdata = []
@@ -185,6 +187,7 @@ class consolelog(object):
             result.append("\n".join(tmpdata))
 
         return result
+
 
 class reporter(object):
     """Abstract test result reporter"""
@@ -228,17 +231,18 @@ class reporter(object):
         return mergedata
 
     def stateconfigdata(self, mergedata):
-        mergedata['base'] = (self.cfg.get("baserepo"), self.cfg.get("basehead"))
-	if self.cfg.get("mergerepos"):
+        mergedata['base'] = (self.cfg.get("baserepo"),
+                             self.cfg.get("basehead"))
+        if self.cfg.get("mergerepos"):
             mrl = self.cfg.get("mergerepos")
             mhl = self.cfg.get("mergeheads")
             for idx in range(0, len(mrl)):
                 mergedata['merge_git'].append((mrl[idx], mhl[idx]))
 
-	if self.cfg.get("localpatches"):
+        if self.cfg.get("localpatches"):
             mergedata['localpatch'] = self.cfg.get("localpatches")
 
-	if self.cfg.get("patchworks"):
+        if self.cfg.get("patchworks"):
             for purl in self.cfg.get("patchworks"):
                 (rpc, patchid) = skt.parse_patchwork_url(purl)
                 pinfo = rpc.patch_get(patchid)
@@ -248,11 +252,11 @@ class reporter(object):
 
     def update_mergedata(self):
         mergedata = {
-                'base' : None,
-                'merge_git' : [],
-                'localpatch' : [],
-                'patchwork' : [],
-                'config' : None,
+                'base': None,
+                'merge_git': [],
+                'localpatch': [],
+                'patchwork': [],
+                'config': None,
                 }
 
         if self.cfg.get("infourl"):
@@ -262,7 +266,7 @@ class reporter(object):
 
         if self.cfg.get("cfgurl"):
             r = requests.get(self.cfg.get("cfgurl"))
-            if r != None:
+            if r is not None:
                 mergedata['config'] = r.text
         else:
             with open("%s/.config" % self.cfg.get("workdir"), "r") as fp:
@@ -273,19 +277,19 @@ class reporter(object):
     def getmergeinfo(self):
         result = []
 
-        result += [ "base repo: %s" % self.mergedata['base'][0],
-                    "     HEAD: %s" % self.mergedata['base'][1] ]
+        result += ["base repo: %s" % self.mergedata['base'][0],
+                   "     HEAD: %s" % self.mergedata['base'][1]]
 
         for (repo, head) in self.mergedata['merge_git']:
-            result += [ "\nmerged git repo: %s" % repo,
-                        "           HEAD: %s" % head ]
+            result += ["\nmerged git repo: %s" % repo,
+                       "           HEAD: %s" % head]
 
         for (patchpath) in self.mergedata['localpatch']:
-            result += [ "\npatch: %s" % patchpath ]
+            result += ["\npatch: %s" % patchpath]
 
         for (purl, pname) in self.mergedata['patchwork']:
-            result += [ "\npatchwork url: %s" % purl,
-                        "         name: %s" % pname ]
+            result += ["\npatchwork url: %s" % purl,
+                       "         name: %s" % pname]
 
         if not self.cfg.get("mergelog"):
             cfgname = "config.gz"
@@ -307,7 +311,7 @@ class reporter(object):
         return result
 
     def getjobids(self):
-	jobids = []
+        jobids = []
         if self.cfg.get("jobs"):
             for jobid in sorted(self.cfg.get("jobs")):
                 jobids.append(jobid)
@@ -317,7 +321,9 @@ class reporter(object):
         result = []
 
         result.append("\n-----------------------")
-        result.append("Merge failed during application of the last patch above:\n")
+        result.append(
+            "Merge failed during application of the last patch above:\n"
+        )
         with open(self.cfg.get("mergelog"), 'r') as fp:
             result.append(fp.read())
         return result
@@ -340,7 +346,7 @@ class reporter(object):
         vresults = runner.getverboseresults(list(self.cfg.get("jobs")))
 
         result.append("\n-----------------------")
-        minfo = { "short": {}, "long": {} }
+        minfo = {"short": {}, "long": {}}
         jidx = 1
         for jobid in sorted(self.cfg.get("jobs")):
             for (recipe, rdata) in vresults[jobid].iteritems():
@@ -353,8 +359,9 @@ class reporter(object):
                 result.append("Test Run: #%d" % jidx)
                 result.append("result: %s" % res)
 
-                if clogurl != None and res != "Pass":
-                    logging.info("Panic detected in recipe %s, attaching console log",
+                if clogurl is not None and res != "Pass":
+                    logging.info("Panic detected in recipe %s, "
+                                 "attaching console log",
                                  recipe)
                     clog = consolelog(self.cfg.get("krelease"), clogurl)
                     ctraces = clog.gettraces()
@@ -364,13 +371,14 @@ class reporter(object):
 
                     if jidx == 1:
                         clfname = "%02d_console.log.gz" % jidx
-                        result.append("full console log attached: %s" % clfname)
+                        result.append("full console log attached: %s"
+                                      % clfname)
                         self.attach.append((clfname, clog.getfulllog()))
 
-                if slshwurl != None:
+                if slshwurl is not None:
                     if system not in minfo["short"]:
                         r = requests.get(slshwurl)
-                        if r != None:
+                        if r is not None:
                             result.append("\nmachine info:")
                             result += r.text.split('\n')
                             minfo["short"][system] = jidx
@@ -387,7 +395,8 @@ class reporter(object):
         msg = list()
 
         if self.cfg.get("krelease"):
-            msg.append("result report for kernel %s" % self.cfg.get("krelease"))
+            msg.append("result report for kernel %s"
+                       % self.cfg.get("krelease"))
 
         msg += self.getmergeinfo()
 
@@ -405,8 +414,9 @@ class reporter(object):
         return '\n'.join(msg)
 
     def getsubject(self):
-        subject = "[skt] [%s] " % ("PASS" if self.cfg.get("retcode") == "0" \
-                                          else "FAIL")
+        subject = "[skt] [%s] " % ("PASS"
+                                   if self.cfg.get("retcode") == "0"
+                                   else "FAIL")
 
         if self.mergedata.get("base"):
             subject += "[%s] " % self.mergedata['base'][0].split("/")[-1]
@@ -424,6 +434,7 @@ class reporter(object):
 
     # TODO Define abstract "report" method.
 
+
 class stdioreporter(reporter):
     """A reporter sending results to stdout"""
     TYPE = 'stdio'
@@ -434,11 +445,12 @@ class stdioreporter(reporter):
         print self.getreport()
 
         for (name, att) in self.attach:
-            if not (name.endswith('.log') or name.endswith('.txt') or \
+            if not (name.endswith('.log') or name.endswith('.txt') or
                     name.endswith('config')):
                 continue
             print "\n---------------\n%s\n" % name
             print att
+
 
 class mailreporter(reporter):
     """A reporter sending results by e-mail"""
@@ -471,14 +483,14 @@ class mailreporter(reporter):
 
         for (name, att) in self.attach:
             # TODO Store content type and charset when adding attachments
-            if (name.endswith('.log') or name.endswith('.txt') or \
+            if (name.endswith('.log') or name.endswith('.txt') or
                     name.endswith('config')):
-		tmp = MIMEText(att, _charset='utf-8')
-		tmp.add_header("content-disposition", "attachment",
+                tmp = MIMEText(att, _charset='utf-8')
+                tmp.add_header("content-disposition", "attachment",
                                filename=name)
             else:
-		tmp = MIMEApplication(att)
-		tmp.add_header("content-disposition", "attachment",
+                tmp = MIMEApplication(att)
+                tmp.add_header("content-disposition", "attachment",
                                filename=name)
 
             msg.attach(tmp)
@@ -486,6 +498,7 @@ class mailreporter(reporter):
         s = smtplib.SMTP('localhost')
         s.sendmail(self.mailfrom, self.mailto, msg.as_string())
         s.quit()
+
 
 def getreporter(rtype, rarg):
     """


### PR DESCRIPTION
This patch fixes the gigantic number of syntax (mainly pep8) violations,
namely:
- multiple imports on the same line and their order
- whitespace issues (whitespaces present around keyword arguments or
  before ':', number of blank lines, missing space after '#' in comment,
  mixed tabs and spaces...)
- conditionals: comparisons with None, True
- too long lines (>79 chars)
- indentation
- bare excepts (left the one in skt/\_\_init\_\_.py since since fixing it
  requires understanding of the code and what exceptions it may throw)

The patch doesn't fix any 'non-pythonic' code, it just makes the first
step towards it with correcting the syntax issues.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>