### PR TITLE
Add flake8 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ python:
     - "2.7"
 install:
     - pip install requests junit_xml beaker-client mock
-    - pip install pylint pycodestyle
+    - pip install pylint pycodestyle flake8
 script:
+    - flake8 --show-source .
     - python -m unittest discover tests
     - pylint tests
-    - pycodestyle .
     - pip install .
     - pip uninstall -y skt

--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -37,6 +37,10 @@ def stringify(v):
         return str(v)
 
 
+class RpcProtocolMismatch(Exception):
+    """Exception for Patchwork API mismatch errors"""
+
+
 # PatchWork adds a magic API version with each call
 # this class just magically adds/removes it
 class RpcWrapper:

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -125,7 +125,7 @@ def cmd_merge(cfg):
         idx = 0
         for mb in cfg.get('merge_ref'):
             save_state(cfg, {'mergerepo_%02d' % idx: mb[0],
-                             'mergehead_%02d' % idx: head})
+                             'mergehead_%02d' % idx: bhead})
             (retcode, head) = ktree.merge_git_ref(*mb)
 
             utypes.append("[git]")

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -124,7 +124,7 @@ def cmd_merge(cfg):
     try:
         idx = 0
         for mb in cfg.get('merge_ref'):
-            save_state(cfg, {'meregerepo_%02d' % idx: mb[0],
+            save_state(cfg, {'mergerepo_%02d' % idx: mb[0],
                              'mergehead_%02d' % idx: head})
             (retcode, head) = ktree.merge_git_ref(*mb)
 

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -19,16 +19,18 @@ import argparse
 import ast
 import datetime
 import json
-import junit_xml
 import logging
 import os
 import shutil
 import sys
 import time
+
+import junit_xml
+
+import skt
 import skt.publisher
 import skt.reporter
 import skt.runner
-import skt
 
 DEFAULTRC = "~/.sktrc"
 logger = logging.getLogger()

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -11,21 +11,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-
-import bkr.client
-from email.mime.application import MIMEApplication
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
+import StringIO
 import gzip
 import logging
 import os
 import re
-import requests
 import smtplib
-import StringIO
-import tempfile
-import xml.etree.ElementTree as etree
-import xmlrpclib
+
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+import requests
+
 import skt
 import skt.runner
 
@@ -354,7 +352,6 @@ class reporter(object):
                     continue
 
                 (res, system, clogurl, slshwurl, llshwurl) = rdata
-                ssys = system.split(".")[0]
 
                 result.append("Test Run: #%d" % jidx)
                 result.append("result: %s" % res)

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -15,6 +15,7 @@ Test cases for publisher module.
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 import unittest
+
 from skt import publisher
 
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -14,11 +14,15 @@ Test cases for reporter module.
 # You should have received a copy of the GNU General Public License along with
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-import unittest
-from contextlib import contextmanager
 import re
+import unittest
+
+from contextlib import contextmanager
+
 import mock
+
 from skt import reporter
+
 from tests import misc
 
 


### PR DESCRIPTION
This patch set adds flake8 testing in the Travis job and also runs
the linting checks prior to the python tests.

Fixes for flake8 issues are included.

Depends on #22 to merge first.
Fixes #24.

Signed-off-by: Major Hayden <major@redhat.com>
