### PR TITLE
README: Add dependency on dnf-plugins-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Install dependencies needed for running skt like this:
 
 Dependencies needed to build kernels:
 
+    $ sudo dnf install bison flex dnf-plugins-core
     $ sudo dnf builddep kernel-`uname -r`
-    $ sudo dnf install bison flex
 
 Extra dependencies needed for running the testsuite:
 


### PR DESCRIPTION
This is required by the 'dnf builddep' tooling.