### PR TITLE
Make building with debuginfo optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ E.g. to build with the current system's config file run:
     $ skt --rc <SKTRC> --state --workdir skt-workdir -vv \
              build -c /boot/config-`uname -r`
 
+**NOTE:** Kernels are built without debuginfo by default to save disk space
+and improve build times. In some cases, deep troubleshooting may require
+debug symbols. Use the `--enable-debuginfo` argument to build a kernel with
+debug symbols included.
+
 ### Publish
 
 To "publish" the resulting build using the simple "cp" (copy) publisher run:

--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -431,7 +431,8 @@ class ktree(object):
 
 
 class kbuilder(object):
-    def __init__(self, path, basecfg, cfgtype=None, makeopts=None):
+    def __init__(self, path, basecfg, cfgtype=None, makeopts=None,
+                 enable_debuginfo=False):
         # FIXME Move expansion up the call stack, as this limits the class
         # usefulness, because tilde is a valid path character.
         self.path = os.path.expanduser(path)
@@ -465,6 +466,15 @@ class kbuilder(object):
             subprocess.check_call(args)
 
         shutil.copyfile(self.basecfg, "%s/.config" % self.path)
+
+        # NOTE(mhayden): Building kernels with debuginfo can increase the
+        # final kernel tarball size by 3-4x and can increase build time
+        # slightly. Debug symbols are really only needed for deep diagnosis
+        # of kernel issues on a specific system. This is why debuginfo is
+        # disabled by default.
+        if not self.enable_debuginfo:
+            logging.info("disabling debuginfo:")
+            subprocess.check_call(["script/config", "--disable debug_info"])
 
         args = self.defmakeargs + [self.cfgtype]
         logging.info("prepare config: %s", args)

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -169,8 +169,13 @@ def cmd_build(cfg):
     tstamp = datetime.datetime.strftime(datetime.datetime.now(),
                                         "%Y%m%d%H%M%S")
 
-    builder = skt.kbuilder(cfg.get('workdir'), cfg.get('baseconfig'),
-                           cfg.get('cfgtype'), cfg.get('makeopts'))
+    builder = skt.kbuilder(
+        cfg.get('workdir'),
+        cfg.get('baseconfig'),
+        cfg.get('cfgtype'),
+        cfg.get('makeopts'),
+        cfg.get('enable_debuginfo')
+    )
 
     try:
         tgz = builder.mktgz(cfg.get('wipe'))
@@ -422,6 +427,12 @@ def setup_parser():
                               help="Path to kernel config to use")
     parser_build.add_argument("--cfgtype", type=str, help="How to process "
                               "default config (default: olddefconfig)")
+    parser_build.add_argument(
+        "--enable-debuginfo",
+        type=bool,
+        default=False,
+        help="Build kernel with debuginfo (default: disabled)"
+    )
     parser_build.add_argument("--makeopts", type=str,
                               help="Additional options to pass to make")
 


### PR DESCRIPTION
By default, kernels are built with debug symbols. This increases the
build time and the size of the resulting tarball.

    tar.gz with debug symbols: ~ 250MB
    tar.gz without debug symbols: ~ 75MB

If debug symbols are really needed for diagnosing a tough problem,
the user can specify `--enable-debuginfo` when calling `skt build`.

Fixes #32.

Signed-off-by: Major Hayden <major@redhat.com>
