### PR TITLE
Allow pip to install dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 python:
     - "2.7"
-install:
-    - pip install requests junit_xml beaker-client mock
-    - pip install pylint flake8
 script:
-    - flake8 --show-source .
-    - python -m unittest discover tests
-    - pylint tests
+    # Install skt using pip to ensure dependencies are downloaded correctly.
     - pip install .
+    # Run tests and linters.
+    - flake8 --show-source .
+    - pylint tests
+    - python -m unittest discover tests
+    # Test the uninstallation of skt,
     - pip uninstall -y skt

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,14 @@ license = GPLv2+
 packages = find:
 # Parse the MANIFEST.in file and include those files, too.
 include_package_data = True
+# Let pip install dependencies automatically.
+install_requires = beaker-client
+                   flake8
+                   junit_xml
+                   mock
+                   pycodestyle
+                   pylint
+                   requests
 
 [options.entry_points]
 # Set up an executable 'skt' that calls the main() function in


### PR DESCRIPTION
This patch adds the dependencies for skt into the `install_requires`
option so that pip can install dependencies automatically. The
Travis-CI configuration is adjusted to test this process as well.

Fixes #36.

Signed-off-by: Major Hayden <major@mhtx.net>

* [x] Needs #25 merged first.