### PR TITLE
Fix missing enable_debuginfo attribute

### DIFF
--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -444,6 +444,7 @@ class kbuilder(object):
         self.makeopts = None
         self.buildlog = "%s/build.log" % self.path
         self.defmakeargs = ["make", "-C", self.path]
+        self.enable_debuginfo = enable_debuginfo
 
         if makeopts is not None:
             # FIXME: Might want something a bit smarter here, something that


### PR DESCRIPTION
Fixes 0d3c31f.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>