### PR TITLE
Fix debuginfo disabling

### DIFF
--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -490,8 +490,11 @@ class kbuilder(object):
         # of kernel issues on a specific system. This is why debuginfo is
         # disabled by default.
         if not self.enable_debuginfo:
-            logging.info("disabling debuginfo:")
-            subprocess.check_call(["script/config", "--disable debug_info"])
+            args = ["%s/scripts/config" % self.path,
+                    "--file", self.get_cfgpath(),
+                    "--disable", "debug_info"]
+            logging.info("disabling debuginfo: %s", args)
+            subprocess.check_call(args)
 
         args = self.defmakeargs + [self.cfgtype]
         logging.info("prepare config: %s", args)


### PR DESCRIPTION
* Log the command being executed.
* Refer to the "config" script by its full pathname, otherwise it cannot
  be found when building outside the source directory.
* Pass the "--file" option, pointing to the configuration, otherwise the
  script cannot find it when building outside the source directory.
* Pass "--disable" and "debug_info" as separate arguments, otherwise the
  option is not recognized by the script.