### PR TITLE
Functional tests in Circle-CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,63 @@
+defaults: &defaults
+  working_directory: /tmp/skt
+  steps:
+    - checkout
+    - run:
+        name: Install skt using pip
+        command: pip install .
+    - run:
+        name: Run Python linters and tests
+        command: |
+          flake8 --show-source .
+          pylint tests
+          python -m unittest discover tests
+    # TODO(mhayden): Add --depth support to skt and then let skt to the clone
+    # rather than using the git command below.
+    - run:
+        name: Clone and prepare repo
+        command: |
+          mkdir -p /tmp/skt_test/workdir
+          git config --global user.name "SKT"
+          git config --global user.email "noreply@redhat.com"
+          git clone --branch v4.16 --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git /tmp/test/workdir
+    - run:
+        name: Test `skt merge`
+        command: |
+          skt -vv --state -d workdir --rc sktrc merge \
+            --pw https://patchwork.ozlabs.org/patch/895383/ \
+            -b git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git \
+            --ref master
+        working_directory: /tmp/skt_test
+    - run:
+        name: Test `skt build`
+        command: |
+            make -C workdir tinyconfig
+            mv workdir/.config config
+            skt -vv --state -d workdir --rc sktrc build -c config
+        working_directory: /tmp/skt_test
+    - store_artifacts:
+        path: /tmp/skt_test/workdir/*.log
+    - store_artifacts:
+        path: /tmp/skt_test/workdir/.config
+    - store_artifacts:
+        path: /tmp/skt_test/*.tar.gz
+    - store_artifacts:
+        path: /tmp/skt_test/sktrc
+
+version: 2
+jobs:
+  fedora27:
+    docker:
+      - image: quay.io/major/fedora-kernel-builder:latest
+    <<: *defaults
+  centos7:
+    docker:
+      - image: quay.io/major/centos-kernel-builder:latest
+    <<: *defaults
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - fedora27
+      - centos7

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Install `skt` directly from git:
 
     $ pip install git+https://github.com/RH-FMK/skt
 
+If support for beaker is required, install ``skt`` with the ``beaker``
+extras:
+
+    $ pip install git+https://github.com/RH-FMK/skt[beaker]
+
 Test the `skt` executable by printing the help text:
 
     $ skt -h

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,13 +12,19 @@ packages = find:
 # Parse the MANIFEST.in file and include those files, too.
 include_package_data = True
 # Let pip install dependencies automatically.
-install_requires = beaker-client
-                   flake8
+install_requires = flake8
                    junit_xml
                    mock
                    pycodestyle
                    pylint
                    requests
+
+# The beaker-client package breaks some Python packaging rules and tries to
+# store content in the system /etc directory. This causes a Sandbox violation
+# in Circle-CI.
+[options.extras_require]
+beaker = beaker-client
+         python-krbV
 
 [options.entry_points]
 # Set up an executable 'skt' that calls the main() function in

--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -360,13 +360,13 @@ class ktree(object):
 
         logging.info("Applying %s", uri)
 
-        gam = subprocess.Popen(["git",
-                                "--work-tree", self.wdir,
-                                "--git-dir", self.gdir,
-                                "am", "-"],
-                               stdin=subprocess.PIPE,
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.STDOUT)
+        gam = subprocess.Popen(
+            ["git", "am", "-"],
+            cwd=self.wdir,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT
+        )
 
         (stdout, stderr) = gam.communicate(pdata)
         retcode = gam.wait()


### PR DESCRIPTION
This PR does three things:

* Makes `beaker-client` an optional installation (includes docs) (fixes #62)
* Fixes a CentOS 7 bug when using `git-am` outside the workdir (fixes #60)
* Adds Circle-CI functional testing for CentOS 7/Fedora 27

Includes three commits:

    0ee9041 Functional tests in Circle-CI
    ba24f8f Switch to workdir before `git am`
    55cc4ba Make beaker-client optional

Signed-off-by: Major Hayden <major@mhtx.net>
