### PR TITLE
Add extra args for `git fetch`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,19 +14,19 @@ defaults: &defaults
     # TODO(mhayden): Add --depth support to skt and then let skt to the clone
     # rather than using the git command below.
     - run:
-        name: Clone and prepare repo
+        name: Prepare git
         command: |
           mkdir -p /tmp/skt_test/workdir
           git config --global user.name "SKT"
           git config --global user.email "noreply@redhat.com"
-          git clone --branch v4.16 --depth 1 git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git /tmp/skt_test/workdir
     - run:
         name: Test `skt merge`
         command: |
           skt -vv --state -d workdir --rc sktrc merge \
             --pw https://patchwork.ozlabs.org/patch/895383/ \
             -b git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git \
-            --ref v4.16
+            --ref v4.16 \
+            --fetch-depth 1
         working_directory: /tmp/skt_test
     - run:
         name: Test `skt build`

--- a/README.md
+++ b/README.md
@@ -165,6 +165,20 @@ E.g. to apply a particular patch to a particular, known-good commit from the
                    --ref a870a02cc963de35452bbed932560ed69725c4f2 \
                    --pw https://patchwork.ozlabs.org/patch/886637
 
+#### Faster clones
+
+In some instances, a full git history is not needed. Shallow clones are git
+repositories that have a truncated history and they can be cloned much faster
+than a full copy of the repository. Use the `--fetch-depth` option with
+`skt merge`:
+
+    $ skt ... merge ... --fetch-depth 5
+
+In the example above, the repository will be cloned with a git history of five
+commits. This speeds up the cloning process, but it also prevents the use of
+any git references (tags, branches, etc) that were made before the last five
+commits.
+
 ### Build
 
 And to build the kernel run:

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -128,9 +128,12 @@ def cmd_merge(cfg):
     """
     global retcode
     utypes = []
-    ktree = skt.ktree(cfg.get('baserepo'),
-                      ref=cfg.get('ref'),
-                      wdir=cfg.get('workdir'))
+    ktree = skt.ktree(
+        cfg.get('baserepo'),
+        ref=cfg.get('ref'),
+        wdir=cfg.get('workdir'),
+        fetch_depth=cfg.get('fetch_depth')
+    )
     bhead = ktree.checkout()
     commitdate = ktree.get_commit_date(bhead)
     save_state(cfg, {'baserepo': cfg.get('baserepo'),
@@ -507,6 +510,15 @@ def setup_parser():
     parser_merge.add_argument("-m", "--merge-ref", nargs="+",
                               help="Merge ref format: 'url [ref]'",
                               action="append")
+    parser_merge.add_argument(
+        "--fetch-depth",
+        type=str,
+        help=(
+            "Create a shallow clone with a history truncated to the "
+            "specified number of commits."
+        ),
+        default=None
+    )
 
     parser_build = subparsers.add_parser("build", add_help=False)
     parser_build.add_argument("-c", "--baseconfig", type=str,


### PR DESCRIPTION
Full clones of upstream kernel repositories take a long time. Using
shallow clones (--depth 1) can save time when a lengthy history is
not needed.

This patch adds an option for users to specify additional arguments
to `git fetch`.

Documentation is included. Fixes #63.