### PR TITLE
Add a restraint for pycodestyle

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,10 +12,12 @@ packages = find:
 # Parse the MANIFEST.in file and include those files, too.
 include_package_data = True
 # Let pip install dependencies automatically.
+# NOTE(mhayden): pycodestyle 2.4.0 has a bug that causes flake8 to fail.
+# Remove the pycodestyle constraint once upstream is fixed.
 install_requires = flake8
                    junit_xml
                    mock
-                   pycodestyle
+                   pycodestyle!=2.4.0
                    pylint
                    requests
 


### PR DESCRIPTION
pycodestyle 2.4.0 has a bug that causes flake8 to fail. This patch
adds a constraint to avoid this version.

Fixes #72.

Signed-off-by: Major Hayden <major@redhat.com>