### PR TITLE
cleanup: check if workdir is specified

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -362,7 +362,7 @@ def cmd_cleanup(cfg):
         except OSError:
             pass
 
-    if cfg.get('wipe'):
+    if cfg.get('wipe') and cfg.get('workdir'):
         # FIXME Move expansion up the call stack, as this limits the function
         # usefulness, because tilde is a valid path character.
         shutil.rmtree(os.path.expanduser(cfg.get('workdir')))


### PR DESCRIPTION
Solves #66. Check if the workdir is specified before attempting to
remove it to avoid exception with --wipe option.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>