### PR TITLE
reporter: job result reporting enhancements

### DIFF
--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -332,11 +332,12 @@ class reporter(object):
     def getjobresults(self):
         result = ["\n-----------------------"]
         runner = skt.runner.getrunner(*self.cfg.get("runner"))
-        vresults = runner.getverboseresults(list(self.cfg.get("jobs")))
+        job_list = sorted(list(self.cfg.get("jobs", [])))
+        vresults = runner.getverboseresults(job_list)
 
         minfo = {"short": {}, "long": {}}
         jidx = 1
-        for jobid in sorted(self.cfg.get("jobs")):
+        for jobid in job_list:
             for (recipe, rdata) in vresults[jobid].iteritems():
                 if recipe == "result":
                     continue

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -330,6 +330,20 @@ class reporter(object):
         return result
 
     def getjobresults(self):
+        """
+        Retrieve job results which should be appended to the report.
+
+        Get job results from runner, check console logs (if present) to filter
+        out infrastructure issues and find call traces. For each test run, add
+            1. Number of test run
+            2. It's result
+            3. If present, info about the machine the test ran on
+        If the testing failed, add first found trace call and attach related
+        console log.
+
+        Returns:
+            A list of lines representing results of test runs.
+        """
         result = ['\n' + '=' * 70 + '\n']
         runner = skt.runner.getrunner(*self.cfg.get("runner"))
         job_list = sorted(list(self.cfg.get("jobs", [])))

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -330,7 +330,7 @@ class reporter(object):
         return result
 
     def getjobresults(self):
-        result = ["\n-----------------------"]
+        result = ['\n' + '=' * 70 + '\n']
         runner = skt.runner.getrunner(*self.cfg.get("runner"))
         job_list = sorted(list(self.cfg.get("jobs", [])))
         vresults = runner.getverboseresults(job_list)
@@ -352,33 +352,34 @@ class reporter(object):
                     # any details is useless so skip it.
                     continue
 
-                result.append("Test Run: #%d" % jidx)
-                result.append("result: %s" % res)
+                result.append("Test run: #%d" % jidx)
+                result.append("Result: %s" % res)
 
                 if res != "Pass":
                     logging.info("Failure detected in recipe %s, attaching "
                                  "console log", recipe)
                     ctraces = clog.gettraces()
                     if ctraces:
-                        result.append("first encountered call trace:")
+                        result.append("This is the first call trace we found:")
                         result.append(ctraces[0])
 
                     clfname = "%02d_console.log.gz" % jidx
-                    result.append("full console log attached: %s" % clfname)
+                    result.append("For more information about the failure, see"
+                                  " attached console log: %s" % clfname)
                     self.attach.append((clfname, clog.getfulllog()))
 
                 if slshwurl is not None:
                     if system not in minfo["short"]:
                         r = requests.get(slshwurl)
                         if r:
-                            result.append("\nmachine info:")
+                            result.append("\nMachine info:")
                             result += r.text.split('\n')
                             minfo["short"][system] = jidx
                     else:
-                        result.append("machine info: same as #%d" %
+                        result.append("Machine info: same as #%d" %
                                       minfo["short"].get(system))
 
-                result.append("---")
+                result.append("-----")
                 jidx += 1
 
         return result

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -74,25 +74,24 @@ class TestConsoleLog(unittest.TestCase):
         """Check it doesn't catch any trace when kernel version doesn't
         match.
         """
-        consolelog = reporter.consolelog('4-4', 'someurl')
         with self.request_get_mocked('x86_one_trace.txt'):
+            consolelog = reporter.consolelog('4-4', 'someurl')
             traces = consolelog.gettraces()
         self.assertListEqual(traces, [])
 
     def test_match_one_trace(self):
         """Check one trace can be extracted from a console log"""
-        consolelog = reporter.consolelog('4-5-fake', 'someurl')
         with self.request_get_mocked('x86_one_trace.txt'):
+            consolelog = reporter.consolelog('4-5-fake', 'someurl')
             traces = consolelog.gettraces()
             self.assertEqual(len(traces), 1)
         expected_trace = self.get_expected_traces('x86_one_trace.txt')[0]
-        expected_trace += '\n'
         self.assertEqual(expected_trace, traces[0])
 
     def test_match_three_traces(self):
         """Check three traces can be extracted from a console log"""
-        consolelog = reporter.consolelog('4.16-fake', 'someurl')
         with self.request_get_mocked('x86_three_traces.txt'):
+            consolelog = reporter.consolelog('4.16-fake', 'someurl')
             traces = consolelog.gettraces()
             self.assertEqual(len(traces), 3)
         expected_traces = self.get_expected_traces('x86_three_traces.txt')


### PR DESCRIPTION
Enhancements related to reporter.getjobresults():
* Console log parsing
  * Move fetchdata() to init for ease of use
  * Refactor to make it clear what's going on
* More friendly wording and cleaner dividing
* Fix #76 - add default for
  `getverboseresults(list(self.cfg.get("jobs", [])))` to ensure we don't
  get a trace call if there are no jobs to report
* Attach console log for every failed job, not only the first one
* Only report failures for the kernel that is actually being tested. We
  don't want to send out reports if the panic occurred with the original
  (not our) kernel, which we did so far.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>