### PR TITLE
Allow user to specify make job count

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -201,7 +201,8 @@ def cmd_build(cfg):
         cfg.get('baseconfig'),
         cfg.get('cfgtype'),
         cfg.get('makeopts'),
-        cfg.get('enable_debuginfo')
+        cfg.get('enable_debuginfo'),
+        cfg.get('jobcount')
     )
 
     try:
@@ -530,6 +531,14 @@ def setup_parser():
         type=bool,
         default=False,
         help="Build kernel with debuginfo (default: disabled)"
+    )
+    parser_build.add_argument(
+        "--jobcount",
+        type=str,
+        help=(
+            "Number of jobs to use when building "
+            "(default: number of CPUs on system)"
+        )
     )
     parser_build.add_argument("--makeopts", type=str,
                               help="Additional options to pass to make")


### PR DESCRIPTION
Users need the ability to increase or decrease the amount of CPU
cores used for kernel builds. This patch adds a `--jobcount` option
for `skt build` that allows a user to specify the amount of CPUs to
use. If a job count is not specified, `skt` will use the number of
CPUs installed in the system as a default.

Fixes: #91

Signed-off-by: Major Hayden <major@redhat.com>