### PR TITLE
Fix bug: skt merge creates relative workdir under workdir

### DIFF
--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -295,6 +295,7 @@ class ktree(object):
         logging.info("checking out %s", self.ref)
         self.git_cmd("checkout", "-q", "--detach", dstref)
         self.git_cmd("reset", "--hard", dstref)
+        self.git_cmd("clean", "-df")
 
         head = self.get_commit()
         self.info.append(("base", self.uri, head))


### PR DESCRIPTION
Hello, 
I create the PR to fix #51. 
I think `skt-workdir` in this issue is an untracked directory. Introducing the `git clean -df` is a convenience method for deleting untracked file in a repo's working tree. Please review my PR and give the feedback. Thanks!