### PR TITLE
Fix: Running `skt publish` without --tarpkg produces stacktrace

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -249,6 +249,9 @@ def cmd_publish(cfg):
     """
     publisher = skt.publisher.getpublisher(*cfg.get('publisher'))
 
+    if not cfg.get('tarpkg'):
+        raise Exception("skt publish is missing \"--tarpkg <path>\" option")
+
     infourl = None
     cfgurl = None
 


### PR DESCRIPTION
I create PR to fix: #16 . I added `raise exception` when skt publish is missing `tarpkg`. Please review my commit when you have a chance. Thanks!