### PR TITLE
Rework patch retrieval from Patchwork

### DIFF
--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -19,110 +19,11 @@ import re
 import shutil
 import subprocess
 import tempfile
-import xmlrpclib
 import sys
 import io
 import time
 from threading import Timer
-
-
-def stringify(v):
-    """Convert any value to a str object
-
-    xmlrpc is not consistent: sometimes the same field
-    is returned a str, sometimes as unicode. We need to
-    handle both cases properly.
-    """
-    if type(v) is str:
-        return v
-    elif type(v) is unicode:
-        return v.encode('utf-8')
-    else:
-        return str(v)
-
-
-class RpcProtocolMismatch(Exception):
-    """Exception for Patchwork API mismatch errors"""
-
-
-# PatchWork adds a magic API version with each call
-# this class just magically adds/removes it
-class RpcWrapper:
-    def __init__(self, real_rpc):
-        self.rpc = real_rpc
-        # patchwork api coded to
-        self.version = 1010
-
-    def _wrap_call(self, rpc, name):
-        # Wrap a RPC call, adding the expected version number as argument
-        fn = getattr(rpc, name)
-
-        def wrapper(*args, **kwargs):
-            return fn(self.version, *args, **kwargs)
-        return wrapper
-
-    def _return_check(self, r):
-        # Returns just the real return value, without the version info.
-        v = self.version
-        if r[0] != v:
-            raise RpcProtocolMismatch(
-                'Patchwork API mismatch (%i, expected %i)' % (r[0], v)
-            )
-        return r[1]
-
-    def _return_unwrapper(self, fn):
-        def unwrap(*args, **kwargs):
-            return self._return_check(fn(*args, **kwargs))
-        return unwrap
-
-    def __getattr__(self, name):
-        # Add the RPC version checking call/return wrappers
-        return self._return_unwrapper(self._wrap_call(self.rpc, name))
-
-
-# FIXME This doesn't just "parse" patchwork URL. Rename/refactor.
-def parse_patchwork_url(uri):
-    """
-    Create a Patchwork XML RPC interface and extract the patch ID from a
-    Patchwork patch URL.
-
-    Args:
-        uri:    The Patchwork patch URL.
-
-    Returns:
-        The created Patchwork XML RPC interface and the patch ID string.
-
-    Raises:
-        str: URL format was not recognized, or an XML RPC
-             compatibility/communication error has occurred and the string
-             describes it.
-    """
-    m = re.match(r"^(.*)/patch/(\d+)/?$", uri)
-    if not m:
-        raise Exception("Can't parse patchwork url: '%s'" % uri)
-
-    baseurl = m.group(1)
-    patchid = m.group(2)
-
-    rpc = xmlrpclib.ServerProxy("%s/xmlrpc/" % baseurl)
-    try:
-        ver = rpc.pw_rpc_version()
-        # check for normal patchwork1 xmlrpc version numbers
-        if not (ver == [1, 3, 0] or ver == 1):
-            raise Exception("Unknown xmlrpc version %s", ver)
-
-    except xmlrpclib.Fault as err:
-        if err.faultCode == 1 and \
-           re.search("index out of range", err.faultString):
-            # possible internal RH instance
-            rpc = RpcWrapper(rpc)
-            ver = rpc.pw_rpc_version()
-            if ver < 1010:
-                raise Exception("Unsupported xmlrpc version %s", ver)
-        else:
-            raise Exception("Unknown xmlrpc fault: %s", err.faultString)
-
-    return (rpc, patchid)
+import requests
 
 
 class ktree(object):
@@ -368,16 +269,17 @@ class ktree(object):
         return (0, head)
 
     def merge_patchwork_patch(self, uri):
-        (rpc, patchid) = parse_patchwork_url(uri)
+        # Use os.path for manipulation with URL because urlparse can't deal
+        # with URLs ending both with and without slash.
+        mbox_url = os.path.join(uri, 'mbox')
 
-        patchinfo = rpc.patch_get(patchid)
+        try:
+            response = requests.get(mbox_url)
+        except requests.exceptions.RequestException:
+            raise()
 
-        if not patchinfo:
-            raise Exception(
-                "Failed to fetch patch info for patch %s" % patchid
-            )
-
-        pdata = stringify(rpc.patch_get_mbox(patchid))
+        if response.status_code != requests.codes.ok:
+            raise Exception('Nonexistent patch passed: %s' % uri)
 
         logging.info("Applying %s", uri)
 
@@ -390,7 +292,7 @@ class ktree(object):
             env=dict(os.environ, **{'LC_ALL': 'C'})
         )
 
-        (stdout, stderr) = gam.communicate(pdata)
+        (stdout, stderr) = gam.communicate(response.content)
         retcode = gam.wait()
 
         if retcode != 0:
@@ -399,10 +301,12 @@ class ktree(object):
             with open(self.mergelog, "w") as fp:
                 fp.write(stdout)
 
-            raise Exception("Failed to apply patch %s" % patchid)
+            raise Exception("Failed to apply patch %s" %
+                            os.path.basename(os.path.normpath(uri)))
 
-        self.info.append(("patchwork", uri,
-                          patchinfo.get("name").replace(',', ';')))
+        # Retrieve patch name from the mbox and add it to mergeinfo
+        patchname = re.findall(r'Subject:\s(.*)', response.content)[0]
+        self.info.append(("patchwork", uri, patchname.replace(',', ';')))
 
     def merge_patch_file(self, path):
         try:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -26,42 +26,6 @@ from mock import Mock
 import skt
 
 
-class TestInit(unittest.TestCase):
-    """Test cases for skt's __init__.py"""
-
-    def test_stringify_with_integer(self):
-        """Ensure stringify() can handle an integer"""
-        myinteger = int(42)
-        result = skt.stringify(myinteger)
-        self.assertIsInstance(result, str)
-        self.assertEqual(result, str(myinteger))
-
-    def test_stringify_with_string(self):
-        """Ensure stringify() can handle a plain string"""
-        mystring = "Test text"
-        result = skt.stringify(mystring)
-        self.assertIsInstance(result, str)
-        self.assertEqual(result, mystring)
-
-    def test_stringify_with_unicode(self):
-        """Ensure stringify() can handle a unicode byte string"""
-        myunicode = unicode("Test text")
-        result = skt.stringify(myunicode)
-        self.assertIsInstance(result, str)
-        self.assertEqual(result, myunicode.encode('utf-8'))
-
-    def test_parse_bad_patchwork_url(self):
-        """Ensure parse_patchwork_url() handles a parsing exception"""
-        patchwork_url = "garbage"
-        with self.assertRaises(Exception) as context:
-            skt.parse_patchwork_url(patchwork_url)
-
-        self.assertTrue(
-            "Can't parse patchwork url: '{}'".format(patchwork_url)
-            in context.exception
-        )
-
-
 class KBuilderTest(unittest.TestCase):
     # (Too many instance attributes) pylint: disable=R0902
     """Test cases for skt.kbuilder class"""


### PR DESCRIPTION
Using solely XMLRPC for patch retrieval can be an issue, especially with
new Patchwork2 instances which have the legacy interface disabled. Let's
get rid of specific interfaces in skt altogether, and use directly URLs
to mbox files for patch retrieval.

Fixes #98

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>