### PR TITLE
Rework merge_patch_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ E.g. to apply a particular patch to a particular, known-good commit from the
                    --ref a870a02cc963de35452bbed932560ed69725c4f2 \
                    --pw https://patchwork.ozlabs.org/patch/886637
 
+To apply a local patch run:
+
+    $ skt --rc <SKTRC> --state --workdir <WORKDIR> -vv \
+             merge --baserepo <REPO_URL> \
+                   --ref <REPO_REF> \
+                   --patchlist <PATH_TO_PATCH>
+
+Here, `<PATH_TO_PATCH>` would be the patch file.
+E.g. to apply a particular patch to a particular, known-good commit from the
+"net-next" repo, run:
+
+     $ skt --rc skt-rc --state --workdir skt-workdir -vv \
+              merge --baserepo git://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git \
+                    --ref a870a02cc963de35452bbed932560ed69725c4f2 \
+                    --patchlist net-next-cxgb4-notify-fatal-error-to-uld-drivers.patch
+
 #### Faster clones
 
 In some instances, a full git history is not needed. Shallow clones are git

--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -364,10 +364,17 @@ class ktree(object):
     def merge_patch_file(self, path):
         if not os.path.exists(path):
             raise Exception("Patch %s not found" % path)
+        args = ["git", "am", path]
         try:
-            self.git_cmd("am", path)
-        except subprocess.CalledProcessError:
+            subprocess.check_output(args,
+                                    cwd=self.wdir,
+                                    env=dict(os.environ, **{'LC_ALL': 'C'}))
+        except subprocess.CalledProcessError as exc:
             self.git_cmd("am", "--abort")
+
+            with open(self.mergelog, "w") as fp:
+                fp.write(exc.output)
+
             raise Exception("Failed to apply patch %s" % path)
 
         self.info.append(("patch", path))

--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -362,6 +362,8 @@ class ktree(object):
         self.info.append(("patchwork", uri, patchname.replace(',', ';')))
 
     def merge_patch_file(self, path):
+        if not os.path.exists(path):
+            raise Exception("Patch %s not found" % path)
         try:
             self.git_cmd("am", path)
         except subprocess.CalledProcessError:

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -157,7 +157,7 @@ def cmd_merge(cfg):
             idx = 0
             for patch in cfg.get('patchlist'):
                 save_state(cfg, {'localpatch_%02d' % idx: patch})
-                ktree.merge_patch_file(patch)
+                ktree.merge_patch_file(os.path.abspath(patch))
                 idx += 1
 
         if cfg.get('pw'):


### PR DESCRIPTION
I make PR to rework `merge_patch_file`. Fix #99.

1. It provides logs if the patch application fails. 
2. It must have `patch` file in `skt-workdir` to merge. So, in code, I copy the patch file in skt to `skt-workdir`, and then remove it. It is really awkward. But I am not sure how to handle it. 
3. I test by download the patch file `mbox` from https://patchwork.ozlabs.org/patch/886637/, and then use command:

```
$ skt --rc skt-rc --state --workdir skt-workdir -vv \
         merge --baserepo git://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git \
                    --ref a870a02cc963de35452bbed932560ed69725c4f2 \
                    --patchlist net-next-cxgb4-notify-fatal-error-to-uld-drivers.patch
```
Could you review it when you have the chance? Thanks