### PR TITLE
Fix docs on installing w/Beaker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Install `skt` directly from git:
 If support for beaker is required, install ``skt`` with the ``beaker``
 extras:
 
-    $ pip install git+https://github.com/RH-FMK/skt[beaker]
+    $ pip install git+https://github.com/rh-fmk/skt.git#egg-project[beaker]
 
 Test the `skt` executable by printing the help text:
 


### PR DESCRIPTION
The method for installing modules with extras has changed. The
method referenced in this patch works for versions of pip before
and after the 10.0.0 release.

Fixes: #103.

Signed-off-by: Major Hayden <major@redhat.com>