### PR TITLE
reporter: Init subject with no logs but retcode

### DIFF
--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -446,9 +446,10 @@ class reporter(object):
         return '\n'.join(msg)
 
     def getsubject(self):
-        if not self.cfg.get('mergelog') and not self.cfg.get('buildlog'):
-            if self.cfg.get('retcode') == '0':
-                subject = 'PASS: '
+        if not self.cfg.get('mergelog') and \
+           not self.cfg.get('buildlog') and \
+           self.cfg.get('retcode') == '0':
+            subject = 'PASS: '
         else:
             subject = 'FAIL: '
 


### PR DESCRIPTION
Initialize subject also when there are no failure logs, but only a
failure retcode, when constructing the report.

This fixes the following issue when creating reports:

    Traceback (most recent call last):
      File "/home/worker/runner/workspace/upstream@27@tmp/virtualenv/bin/skt", line 11, in <module>
	sys.exit(main())
      File "/home/worker/runner/workspace/upstream@27@tmp/virtualenv/lib/python2.7/site-packages/skt/executable.py", line 713, in main
	args.func(cfg)
      File "/home/worker/runner/workspace/upstream@27@tmp/virtualenv/lib/python2.7/site-packages/skt/executable.py", line 335, in cmd_report
	reporter.report()
      File "/home/worker/runner/workspace/upstream@27@tmp/virtualenv/lib/python2.7/site-packages/skt/reporter.py", line 513, in report
	msg['Subject'] = self.getsubject()
      File "/home/worker/runner/workspace/upstream@27@tmp/virtualenv/lib/python2.7/site-packages/skt/reporter.py", line 460, in getsubject
	subject += "Report"
    UnboundLocalError: local variable 'subject' referenced before assignment