### PR TITLE
Rework patch retrieval from Patchwork

### DIFF
--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -242,9 +242,9 @@ class reporter(object):
 
         if self.cfg.get("patchworks"):
             for purl in self.cfg.get("patchworks"):
-                (rpc, patchid) = skt.parse_patchwork_url(purl)
-                pinfo = rpc.patch_get(patchid)
-                mergedata['patchwork'].append((purl, pinfo.get("name")))
+                patch_mbox = skt.get_patch_mbox(purl)
+                patchname = skt.get_patch_subject(patch_mbox)
+                mergedata['patchwork'].append((purl, patchname))
 
         return mergedata
 


### PR DESCRIPTION
Using XMLRPC for patch retrieval can pose a problem especially with
newer Patchwork2 which have the legacy interface disbled. For the
limited functionality skt needs, retrieving patch mbox is enough and
compatible with both Patchwork1 and Patchwork2 versions.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>