### PR TITLE
Add function for expanding full paths to files/directories

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -38,6 +38,11 @@ logger = logging.getLogger()
 retcode = 0
 
 
+def full_path(path):
+    """Get an absolute path to a file"""
+    return os.path.abspath(os.path.expanduser(path))
+
+
 def save_state(cfg, state):
     """
     Merge state to cfg, and then save cfg.

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -1,0 +1,38 @@
+"""
+Test cases for runner module.
+"""
+# Copyright (c) 2018 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
+# redistribute it subject to the terms and conditions of the GNU General Public
+# License v.2 or later.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+import os
+import unittest
+
+from skt import executable
+
+
+class TestExecutable(unittest.TestCase):
+    """Test cases for executable module"""
+
+    def test_full_path_relative(self):
+        """Verify that full_path() expands a relative path"""
+        filename = "somefile"
+        result = executable.full_path(filename)
+        expected_path = "{}/{}".format(os.getcwd(), filename)
+        self.assertEqual(expected_path, result)
+
+    def test_full_path_user_directory(self):
+        """Verify that full_path() expands a user directory path"""
+        filename = "somefile"
+        result = executable.full_path("~/{}".format(filename))
+        expected_path = "{}/{}".format(os.path.expanduser('~'), filename)
+        self.assertEqual(expected_path, result)


### PR DESCRIPTION
This PR does two things:

- Adds a simply function for getting the full path to files/directories
- Adds tests for the new ``full_path()`` function

This is a partial fix for #94.

- [x]  #127 must merge first