### PR TITLE
Expand workdir paths earlier

### DIFF
--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -105,10 +105,8 @@ class ktree(object):
                     The amount of git history to include with the clone.
                     Smaller depths lead to faster repo clones.
         """
-        # FIXME Move expansion up the call stack, as this limits the class
-        # usefulness, because tilde is a valid path character.
         # The git "working directory" (the "checkout")
-        self.wdir = os.path.expanduser(wdir)
+        self.wdir = wdir
         # The cloned git repository
         self.gdir = "%s/.git" % self.wdir
         # The origin remote's URL
@@ -434,9 +432,7 @@ class ktree(object):
 class kbuilder(object):
     def __init__(self, path, basecfg, cfgtype=None, makeopts=None,
                  enable_debuginfo=False):
-        # FIXME Move expansion up the call stack, as this limits the class
-        # usefulness, because tilde is a valid path character.
-        self.path = os.path.expanduser(path)
+        self.path = path
         # FIXME Move expansion up the call stack, as this limits the class
         # usefulness, because tilde is a valid path character.
         self.basecfg = os.path.expanduser(basecfg)

--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -21,7 +21,6 @@ import os
 import re
 import shutil
 import subprocess
-import tempfile
 import sys
 import io
 import time
@@ -109,9 +108,7 @@ class ktree(object):
         # FIXME Move expansion up the call stack, as this limits the class
         # usefulness, because tilde is a valid path character.
         # The git "working directory" (the "checkout")
-        self.wdir = (os.path.expanduser(wdir)
-                     if wdir is not None
-                     else tempfile.mkdtemp())
+        self.wdir = os.path.expanduser(wdir)
         # The cloned git repository
         self.gdir = "%s/.git" % self.wdir
         # The origin remote's URL

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -23,6 +23,7 @@ import logging
 import os
 import shutil
 import sys
+import tempfile
 import time
 import traceback
 
@@ -487,7 +488,13 @@ def setup_parser():
     """
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("-d", "--workdir", type=str, help="Path to work dir")
+    parser.add_argument(
+        "-d",
+        "--workdir",
+        default=tempfile.mkdtemp(),
+        type=str,
+        help="Path to work dir"
+    )
     parser.add_argument("-w", "--wipe",
                         help="Clean build (make mrproper before building), "
                         "remove workdir when finished",

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -372,9 +372,7 @@ def cmd_cleanup(cfg):
             pass
 
     if cfg.get('wipe') and cfg.get('workdir'):
-        # FIXME Move expansion up the call stack, as this limits the function
-        # usefulness, because tilde is a valid path character.
-        shutil.rmtree(os.path.expanduser(cfg.get('workdir')))
+        shutil.rmtree(cfg.get('workdir'))
 
 
 def cmd_all(cfg):
@@ -709,6 +707,10 @@ def load_config(args):
 
     if cfg.get("bisect"):
         cfg['wait'] = True
+
+    # Get absolute paths for files and directories
+    if cfg.get('workdir'):
+        cfg['workdir'] = full_path(cfg.get('workdir'))
 
     return cfg
 


### PR DESCRIPTION
Expanding paths within the operations of `skt` could lead to situations where paths are different depending on the operation being run. This PR ensures that work directories are expanded as early as possible and all operations will use the same absolute path.

Partial fix for #94.

- [x] Requires #126 to merge first.