### PR TITLE
Expand basecfg path earlier

### DIFF
--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -433,9 +433,7 @@ class kbuilder(object):
     def __init__(self, path, basecfg, cfgtype=None, makeopts=None,
                  enable_debuginfo=False):
         self.path = path
-        # FIXME Move expansion up the call stack, as this limits the class
-        # usefulness, because tilde is a valid path character.
-        self.basecfg = os.path.expanduser(basecfg)
+        self.basecfg = basecfg
         self.cfgtype = cfgtype if cfgtype is not None else "olddefconfig"
         self._ready = 0
         self.makeopts = None

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -711,6 +711,8 @@ def load_config(args):
     # Get absolute paths for files and directories
     if cfg.get('workdir'):
         cfg['workdir'] = full_path(cfg.get('workdir'))
+    if cfg.get('basecfg'):
+        cfg['basecfg'] = full_path(cfg.get('basecfg'))
 
     return cfg
 


### PR DESCRIPTION
Expanding the `basecfg` path earlier ensures that any function that uses the path to the base kernel config is getting the same absolute path to the file.

Partial fix for #94.

- [x] Requires #126 to merge first.
- [x] Requires #128 to merge next.