### PR TITLE
Say in the report why the rest of the series is not mentioned

### DIFF
--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -334,6 +334,10 @@ class reporter(object):
                     break
                 result.append('    ' + line.strip())
 
+        result += ['\nPlease note that if there are subsequent patches in the '
+                   'series, they weren\'t',
+                   'applied because of the error message stated above.\n']
+
         return result
 
     def getbuildfailure(self):


### PR DESCRIPTION
The report of patch application failures said that the application
failed on the last patch mentioned above, however it didn't mention
anything about the rest of the series. This prompted some questions
about a possible bug because it wasn't clear the patches shoudln't be
there. We should say it explicitely in the report.

Fixes #136

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>