### PR TITLE
Fix the ordering of imports

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ include_package_data = True
 # NOTE(mhayden): pycodestyle 2.4.0 has a bug that causes flake8 to fail.
 # Remove the pycodestyle constraint once upstream is fixed.
 install_requires = flake8
+                   flake8-import-order
                    junit_xml
                    mock
                    pycodestyle!=2.4.0

--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -12,9 +12,9 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-from email.errors import HeaderParseError
 import email.header
 import email.parser
+import io
 import logging
 import multiprocessing
 import os
@@ -22,9 +22,10 @@ import re
 import shutil
 import subprocess
 import sys
-import io
 import time
+from email.errors import HeaderParseError
 from threading import Timer
+
 import requests
 
 

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -12,15 +12,16 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 from __future__ import print_function
-from email.mime.application import MIMEApplication
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
+
+import StringIO
 import gzip
 import logging
 import os
 import re
 import smtplib
-import StringIO
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
 
 import requests
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -15,13 +15,16 @@ Test cases for __init__.py.
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 from __future__ import division
-import unittest
-import tempfile
-import shutil
+
 import os
+import shutil
 import subprocess
+import tempfile
+import unittest
+
 import mock
 from mock import Mock
+
 from requests.exceptions import RequestException
 
 import skt

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -16,7 +16,6 @@ Test cases for reporter module.
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 import re
 import unittest
-
 from contextlib import contextmanager
 
 import mock

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -17,8 +17,8 @@ Test cases for runner module.
 import os
 import tempfile
 import unittest
-
 import xml.etree.ElementTree as etree
+
 import mock
 
 from skt import runner


### PR DESCRIPTION
This PR works towards the goals of #3 by ordering imports properly and checking those imports with `flake8-import-order`.