### PR TITLE
Use consistent file handle naming

### DIFF
--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -352,8 +352,8 @@ class KernelTree(object):
         if retcode != 0:
             self.git_cmd("am", "--abort")
 
-            with open(self.mergelog, "w") as fp:
-                fp.write(stdout)
+            with open(self.mergelog, "w") as fileh:
+                fileh.write(stdout)
 
             raise Exception("Failed to apply patch %s" %
                             os.path.basename(os.path.normpath(uri)))
@@ -375,8 +375,8 @@ class KernelTree(object):
         except subprocess.CalledProcessError as exc:
             self.git_cmd("am", "--abort")
 
-            with open(self.mergelog, "w") as fp:
-                fp.write(exc.output)
+            with open(self.mergelog, "w") as fileh:
+                fileh.write(exc.output)
 
             raise Exception("Failed to apply patch %s" % path)
 

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -68,8 +68,8 @@ def save_state(cfg, state):
             logging.debug("state: %s -> %s", key, val)
             config.set('state', key, val)
 
-    with open(cfg.get('rc'), 'w') as fp:
-        config.write(fp)
+    with open(cfg.get('rc'), 'w') as fileh:
+        config.write(fileh)
 
 
 def junit(func):
@@ -352,8 +352,8 @@ def cmd_cleanup(cfg):
     config = cfg.get('_parser')
     if config.has_section('state'):
         config.remove_section('state')
-        with open(cfg.get('rc'), 'w') as fp:
-            config.write(fp)
+        with open(cfg.get('rc'), 'w') as fileh:
+            config.write(fileh)
 
     if cfg.get('buildinfo'):
         try:
@@ -858,8 +858,8 @@ def main():
     args.func(cfg)
     if cfg.get('junit'):
         ts = junit_xml.TestSuite("skt", cfg.get('_testcases'))
-        with open("%s/%s.xml" % (cfg.get('junit'), args._name), 'w') as fp:
-            junit_xml.TestSuite.to_file(fp, [ts])
+        with open("%s/%s.xml" % (cfg.get('junit'), args._name), 'w') as fileh:
+            junit_xml.TestSuite.to_file(fileh, [ts])
 
     sys.exit(retcode)
 

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -270,8 +270,8 @@ class Reporter(object):
             if response:
                 mergedata['config'] = response.text
         else:
-            with open("%s/.config" % self.cfg.get("workdir"), "r") as fp:
-                mergedata['config'] = fp.read()
+            with open("%s/.config" % self.cfg.get("workdir"), "r") as fileh:
+                mergedata['config'] = fileh.read()
 
         self.mergedata = mergedata
 
@@ -329,8 +329,8 @@ class Reporter(object):
                   'failed with the',
                   'following output:\n']
 
-        with open(self.cfg.get("mergelog"), 'r') as fp:
-            for line in fp:
+        with open(self.cfg.get("mergelog"), 'r') as fileh:
+            for line in fileh:
                 # Skip the useless part of the 'git am' output
                 if "The copy of the patch" in line:
                     break
@@ -348,8 +348,8 @@ class Reporter(object):
                   'output for',
                   'more information (%s).' % attname]
 
-        with open(self.cfg.get("buildlog"), 'r') as fp:
-            self.attach.append((attname, gzipdata(fp.read())))
+        with open(self.cfg.get("buildlog"), 'r') as fileh:
+            self.attach.append((attname, gzipdata(fileh.read())))
 
         return result
 

--- a/skt/runner.py
+++ b/skt/runner.py
@@ -83,8 +83,8 @@ class BeakerRunner(Runner):
             The job XML text with template replacements applied.
         """
         xml = ''
-        with open(self.template, 'r') as f:
-            for line in f:
+        with open(self.template, 'r') as fileh:
+            for line in fileh:
                 for match in re.finditer(r"##(\w+)##", line):
                     if match.group(1) in replacements:
                         line = line.replace(match.group(0),
@@ -128,8 +128,8 @@ class BeakerRunner(Runner):
         args.append(jobid)
 
         fname = "%s/%s.xml" % (junit, jobid.replace(":", "_").lower())
-        with open(fname, 'w') as fp:
-            bkr = subprocess.Popen(args, stdout=fp)
+        with open(fname, 'w') as fileh:
+            bkr = subprocess.Popen(args, stdout=fileh)
             bkr.communicate()
 
     def getconsolelog(self, jobid=None):


### PR DESCRIPTION
Fix variable names that violate pylint C0103 and use the same
name for all file handles.

Works towards #3.

Signed-off-by: Major Hayden <major@redhat.com>