### PR TITLE
Simplify response code check

### DIFF
--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -50,7 +50,7 @@ def get_patch_mbox(url):
     except requests.exceptions.RequestException as exc:
         raise(exc)
 
-    if response.status_code != requests.codes.ok:
+    if not response.ok:
         raise Exception('Failed to retrieve patch from %s, returned %d' %
                         (url, response.status_code))
 


### PR DESCRIPTION
The response object has an `ok` method that returns True if the status
code is < 400.

This works towards #3.

Signed-off-by: Major Hayden <major@redhat.com>