### PR TITLE
Rename kbuilder to KernelBuilder

### DIFF
--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -436,7 +436,7 @@ class ktree(object):
         return (ret, binfo)
 
 
-class kbuilder(object):
+class KernelBuilder(object):
     def __init__(self, path, basecfg, cfgtype=None, makeopts=None,
                  enable_debuginfo=False):
         self.path = path

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -200,7 +200,7 @@ def cmd_build(cfg):
     tstamp = datetime.datetime.strftime(datetime.datetime.now(),
                                         "%Y%m%d%H%M%S")
 
-    builder = skt.kbuilder(
+    builder = skt.KernelBuilder(
         cfg.get('workdir'),
         cfg.get('baseconfig'),
         cfg.get('cfgtype'),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -67,11 +67,11 @@ class TestIndependent(unittest.TestCase):
 
 class KBuilderTest(unittest.TestCase):
     # (Too many instance attributes) pylint: disable=R0902
-    """Test cases for skt.kbuilder class"""
+    """Test cases for skt.KernelBuilder class"""
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
         self.tmpconfig = tempfile.NamedTemporaryFile()
-        self.kbuilder = skt.kbuilder(self.tmpdir, self.tmpconfig.name)
+        self.kbuilder = skt.KernelBuilder(self.tmpdir, self.tmpconfig.name)
         self.m_popen = Mock()
         self.m_popen.returncode = 0
         self.ctx_popen = mock.patch('subprocess.Popen',


### PR DESCRIPTION
The name `kbuilder` violates class naming requirements set by pylint.

This PR works towards #3.

Signed-off-by: Major Hayden <major@redhat.com>