### PR TITLE
Rename ktree to KernelTree

### DIFF
--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -93,14 +93,14 @@ def get_patch_name(content):
     return ''.join(decoded)
 
 
-class ktree(object):
+class KernelTree(object):
     """
-    Ktree - a kernel git repository "checkout", i.e. a clone with a working
-    directory
+    KernelTree - a kernel git repository "checkout", i.e. a clone with a
+    working directory
     """
     def __init__(self, uri, ref=None, wdir=None, fetch_depth=None):
         """
-        Initialize a ktree.
+        Initialize a KernelTree.
 
         Args:
             uri:    The Git URI of the repository's origin remote.

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -132,7 +132,7 @@ def cmd_merge(cfg):
     """
     global retcode
     utypes = []
-    ktree = skt.ktree(
+    ktree = skt.KernelTree(
         cfg.get('baserepo'),
         ref=cfg.get('ref'),
         wdir=cfg.get('workdir'),
@@ -402,9 +402,11 @@ def cmd_bisect(cfg):
             "Bisecting currently works only with exactly one mergeref"
         )
 
-    ktree = skt.ktree(cfg.get('baserepo'),
-                      ref=cfg.get('commitgood'),
-                      wdir=cfg.get('workdir'))
+    ktree = skt.KernelTree(
+        cfg.get('baserepo'),
+        ref=cfg.get('commitgood'),
+        wdir=cfg.get('workdir')
+    )
     head = ktree.checkout()
 
     cfg['workdir'] = ktree.getpath()


### PR DESCRIPTION
The name `ktree` violates class naming requirements set by pylint.

This PR works towards #3.

Signed-off-by: Major Hayden <major@redhat.com>