### PR TITLE
Rename class in publisher, and report by using the CapWords convention

### DIFF
--- a/skt/publisher.py
+++ b/skt/publisher.py
@@ -18,7 +18,7 @@ import shutil
 import subprocess
 
 
-class publisher(object):
+class Publisher(object):
     """An abstract result publisher"""
     # TODO This probably shouldn't be here as we never use it, and it should
     # not be inherited
@@ -54,7 +54,7 @@ class publisher(object):
     # TODO Define abstract "publish" method.
 
 
-class cppublisher(publisher):
+class cppublisher(Publisher):
     TYPE = 'cp'
 
     def publish(self, source):
@@ -64,7 +64,7 @@ class cppublisher(publisher):
         return self.geturl(source)
 
 
-class scppublisher(publisher):
+class scppublisher(Publisher):
     TYPE = 'scp'
 
     def publish(self, source):
@@ -90,7 +90,7 @@ def getpublisher(ptype, parg, pburl):
     Raises:
         ValueError if the rtype match wasn't found.
     """
-    for cls in publisher.__subclasses__():
+    for cls in Publisher.__subclasses__():
         if cls.TYPE == ptype:
             return cls(parg, pburl)
     raise ValueError("Unknown publisher type: %s" % ptype)

--- a/skt/publisher.py
+++ b/skt/publisher.py
@@ -54,7 +54,7 @@ class Publisher(object):
     # TODO Define abstract "publish" method.
 
 
-class cppublisher(Publisher):
+class CpPublisher(Publisher):
     TYPE = 'cp'
 
     def publish(self, source):

--- a/skt/publisher.py
+++ b/skt/publisher.py
@@ -64,7 +64,7 @@ class CpPublisher(Publisher):
         return self.geturl(source)
 
 
-class scppublisher(Publisher):
+class ScpPublisher(Publisher):
     TYPE = 'scp'
 
     def publish(self, source):

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -44,7 +44,7 @@ def gzipdata(data):
     return tstr.getvalue()
 
 
-class consolelog(object):
+class ConsoleLog(object):
     """Console log parser"""
 
     # List of regular expression strings matching
@@ -387,7 +387,7 @@ class reporter(object):
 
                 (res, system, clogurl, slshwurl, llshwurl) = rdata
 
-                clog = consolelog(self.cfg.get("krelease"), clogurl)
+                clog = ConsoleLog(self.cfg.get("krelease"), clogurl)
                 if not clog.data and res != 'Pass':
                     # The targeted kernel either didn't start booting or the
                     # console wasn't logged. The second one isn't an issue if

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -484,7 +484,7 @@ class Reporter(object):
     # TODO Define abstract "report" method.
 
 
-class stdioreporter(Reporter):
+class StdioReporter(Reporter):
     """A reporter sending results to stdout"""
     TYPE = 'stdio'
 

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -499,7 +499,7 @@ class StdioReporter(Reporter):
                 print(att)
 
 
-class mailreporter(Reporter):
+class MailReporter(Reporter):
     """A reporter sending results by e-mail"""
     TYPE = 'mail'
 
@@ -527,7 +527,7 @@ class mailreporter(Reporter):
         # The value of "In-Reply-To" header
         self.mailinreplyto = mailinreplyto
         self.subject = subject
-        super(mailreporter, self).__init__(cfg)
+        super(MailReporter, self).__init__(cfg)
 
     def report(self):
         self.update_mergedata()

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -189,7 +189,7 @@ class ConsoleLog(object):
         return result
 
 
-class reporter(object):
+class Reporter(object):
     """Abstract test result reporter"""
     # TODO This probably shouldn't be here as we never use it, and it should
     # not be inherited
@@ -484,7 +484,7 @@ class reporter(object):
     # TODO Define abstract "report" method.
 
 
-class stdioreporter(reporter):
+class stdioreporter(Reporter):
     """A reporter sending results to stdout"""
     TYPE = 'stdio'
 
@@ -499,7 +499,7 @@ class stdioreporter(reporter):
                 print(att)
 
 
-class mailreporter(reporter):
+class mailreporter(Reporter):
     """A reporter sending results by e-mail"""
     TYPE = 'mail'
 
@@ -572,7 +572,7 @@ def getreporter(rtype, rarg):
     Raises:
         ValueError if the rtype match wasn't found.
     """
-    for cls in reporter.__subclasses__():
+    for cls in Reporter.__subclasses__():
         if cls.TYPE == rtype:
             return cls(**rarg)
     raise ValueError("Unknown reporter type: %s" % rtype)

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -20,8 +20,8 @@ from skt import publisher
 
 
 class TestPublisher(unittest.TestCase):
-    """Test cases for publisher.publisher class"""
+    """Test cases for publisher.Publisher class"""
     def test_geturl(self):
         """Check if the source url is built correctly"""
-        pub = publisher.publisher('dest', 'file:///tmp/test')
+        pub = publisher.Publisher('dest', 'file:///tmp/test')
         self.assertEqual(pub.geturl('source'), 'file:///tmp/test/source')

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -27,11 +27,11 @@ from tests import misc
 
 
 class TestConsoleLog(unittest.TestCase):
-    """Test cases for reporter.consolelog class"""
+    """Test cases for reporter.ConsoleLog class"""
     @staticmethod
     @contextmanager
     def request_get_mocked(filename):
-        """Mock request.get to allow feeding consolelog with known inputs. When
+        """Mock request.get to allow feeding ConsoleLog with known inputs. When
         request.get is called, it "fetches" the content of the asset passed as
         parameter.
 
@@ -75,14 +75,14 @@ class TestConsoleLog(unittest.TestCase):
         match.
         """
         with self.request_get_mocked('x86_one_trace.txt'):
-            consolelog = reporter.consolelog('4-4', 'someurl')
+            consolelog = reporter.ConsoleLog('4-4', 'someurl')
             traces = consolelog.gettraces()
         self.assertListEqual(traces, [])
 
     def test_match_one_trace(self):
         """Check one trace can be extracted from a console log"""
         with self.request_get_mocked('x86_one_trace.txt'):
-            consolelog = reporter.consolelog('4-5-fake', 'someurl')
+            consolelog = reporter.ConsoleLog('4-5-fake', 'someurl')
             traces = consolelog.gettraces()
             self.assertEqual(len(traces), 1)
         expected_trace = self.get_expected_traces('x86_one_trace.txt')[0]
@@ -91,7 +91,7 @@ class TestConsoleLog(unittest.TestCase):
     def test_match_three_traces(self):
         """Check three traces can be extracted from a console log"""
         with self.request_get_mocked('x86_three_traces.txt'):
-            consolelog = reporter.consolelog('4.16-fake', 'someurl')
+            consolelog = reporter.ConsoleLog('4.16-fake', 'someurl')
             traces = consolelog.gettraces()
             self.assertEqual(len(traces), 3)
         expected_traces = self.get_expected_traces('x86_three_traces.txt')


### PR DESCRIPTION
PR to rename class in publisher, and report by using the CapWords convention
Resolve #3 