### PR TITLE
[WIP] Store kernel source in a directory

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -135,7 +135,7 @@ def cmd_merge(cfg):
     ktree = skt.KernelTree(
         cfg.get('baserepo'),
         ref=cfg.get('ref'),
-        wdir=cfg.get('workdir'),
+        workdir=cfg.get('workdir'),
         fetch_depth=cfg.get('fetch_depth')
     )
     bhead = ktree.checkout()


### PR DESCRIPTION
This PR renames `wdir` to `workdir` to make it more clear. Also, it clones/fetches the kernel source into `workdir/source`. This allows work for #84 to continue since it allows multiple directories to exist inside the workdir without conflicts.