### PR TITLE
Add new YAML state file functions/tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires = flake8
                    pycodestyle!=2.4.0
                    pylint
                    requests
+                   PyYAML
 
 # The beaker-client package breaks some Python packaging rules and tries to
 # store content in the system /etc directory. This causes a Sandbox violation

--- a/skt/state_file.py
+++ b/skt/state_file.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python2
+
+# Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
+# redistribute it subject to the terms and conditions of the GNU General
+# Public License v.2 or later.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""Functions that manage the skt state file."""
+import logging
+import os
+import yaml
+
+
+def destroy(cfg):
+    """
+    Destroy the state file.
+
+    Args:
+        cfg: A dictionary of skt configuration
+    """
+    state_file = cfg.get('state')
+
+    if os.path.isfile(state_file):
+        try:
+            os.unlink(state_file)
+        except IOError as exception:
+            logging.error("Failed to delete state file: %s", exception)
+            raise exception
+
+
+def read(cfg):
+    """
+    Read the state file from the disk.
+
+    Args:
+        cfg: A dictionary of skt configuration
+    """
+    # Return an empty state dictionary if the state file does not exist
+    current_state = {}
+
+    state_file = cfg.get('state')
+    logging.debug("Reading state from: %s", state_file)
+
+    if os.path.isfile(state_file):
+        try:
+            with open(state_file, 'r') as fileh:
+                current_state = yaml.load(fileh)
+        except IOError as exception:
+            logging.error("Failed to read state file: %s", exception)
+            raise exception
+
+    return current_state
+
+
+def update(cfg, state_updates):
+    """
+    Update the state file on disk with new state data.
+
+    Args:
+        cfg:           A dictionary of skt configuration.
+        state_updates: A dictionary of items to update.
+    """
+    current_state = read(cfg)
+
+    # Merge the current state and the updates.
+    new_state = current_state.copy()
+    new_state.update(state_updates)
+
+    # Save the new state to the state file
+    logging.debug("Saving state: %s", state_updates)
+    state_file = cfg.get('state')
+
+    try:
+        with open(state_file, 'w') as fileh:
+            yaml_state = yaml.dump(new_state, default_flow_style=False)
+            fileh.write(yaml_state)
+    except IOError as exception:
+        logging.error("Failed to update state file: %s", exception)
+        raise exception

--- a/tests/test_state_file.py
+++ b/tests/test_state_file.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2018 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
+# redistribute it subject to the terms and conditions of the GNU General Public
+# License v.2 or later.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""Test cases for state_file functions."""
+import os
+import tempfile
+import unittest
+
+import mock
+
+from skt import state_file
+
+
+def exception_maker(*args, **kwargs):  # pylint: disable=W0613
+    """Test function for throwing an exception."""
+    raise IOError("Simulated test failure")
+
+
+class TestStateFile(unittest.TestCase):
+    """Test cases for state_file module."""
+
+    def setUp(self):
+        """Text fixtures."""
+        self.tempyaml = "---\nfoo: bar"
+
+    def prep_temporary_state_file(self):
+        """Prepare a temporary state file."""
+        tempstate = tempfile.NamedTemporaryFile(delete=False)
+        tempstate.write(self.tempyaml)
+        tempstate.close()
+        cfg = {'state': tempstate.name}
+        return cfg
+
+    def test_destroy_state_file(self):
+        """Ensure destroy() deletes the state file."""
+        cfg = self.prep_temporary_state_file()
+
+        state_file.destroy(cfg)
+        self.assertFalse(os.path.isfile(cfg['state']))
+
+    @mock.patch('os.unlink', side_effect=exception_maker)
+    def test_destroy_state_file_failure(self, mockobj):
+        """Ensure destroy() fails when state file cannot be deleted."""
+        # pylint: disable=W0613
+        cfg = self.prep_temporary_state_file()
+
+        with self.assertRaises(IOError):
+            state_file.destroy(cfg)
+
+    def test_read_state_file(self):
+        """Ensure read() reads the state file."""
+        cfg = self.prep_temporary_state_file()
+
+        test_yaml = state_file.read(cfg)
+        self.assertDictEqual(test_yaml, {'foo': 'bar'})
+
+        os.unlink(cfg['state'])
+
+    @mock.patch('yaml.load', side_effect=exception_maker)
+    def test_read_state_file_failure(self, mockobj):
+        """Ensure read() fails when state file is unreadable."""
+        # pylint: disable=W0613
+        cfg = self.prep_temporary_state_file()
+
+        with self.assertRaises(IOError):
+            state_file.read(cfg)
+
+        os.unlink(cfg['state'])
+
+    def test_update_state_file(self):
+        """Ensure update() updates the state file."""
+        cfg = self.prep_temporary_state_file()
+
+        # Write some new state
+        new_state = {'foo2': 'bar2'}
+        state_file.update(cfg, new_state)
+
+        # Read in the state file to verify the new state was written
+        state_data = state_file.read(cfg)
+
+        expected_dict = {
+            'foo': 'bar',
+            'foo2': 'bar2',
+        }
+        self.assertDictEqual(state_data, expected_dict)
+
+        os.unlink(cfg['state'])
+
+    @mock.patch('yaml.dump', side_effect=exception_maker)
+    def test_update_state_file_failure(self, mockobj):
+        """Ensure update() fails when the state file cannot be updated."""
+        # pylint: disable=W0613
+        cfg = self.prep_temporary_state_file()
+
+        # Write some new state
+        new_state = {'foo2': 'bar2'}
+        with self.assertRaises(IOError):
+            state_file.update(cfg, new_state)
+
+        os.unlink(cfg['state'])


### PR DESCRIPTION
This PR contains the initial work for YAML-formatted state files. These functions are not yet in use by `skt`, so merging this code should not affect an existing deployment.

The PR that adds code that uses these functions is in progress.