### PR TITLE
KernelBuilder: Add generic adjust_config_option()

### DIFF
--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -78,11 +78,7 @@ class KernelBuilder(object):
         # of kernel issues on a specific system. This is why debuginfo is
         # disabled by default.
         if not self.enable_debuginfo:
-            args = ["%s/scripts/config" % self.source_dir,
-                    "--file", self.get_cfgpath(),
-                    "--disable", "debug_info"]
-            logging.info("disabling debuginfo: %s", args)
-            subprocess.check_call(args)
+            self.adjust_config_option('disable', 'debug_info')
 
         args = self.make_argv_base + [self.cfgtype]
         logging.info("prepare config: %s", args)

--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -50,6 +50,20 @@ class KernelBuilder(object):
         logging.info("basecfg: %s", self.basecfg)
         logging.info("cfgtype: %s", self.cfgtype)
 
+    def adjust_config_option(self, action, option):
+        """Adjust a kernel config option using kernel scripts."""
+        if action not in ['enable', 'disable']:
+            raise LookupError("Only 'enable' and 'disable' are supported.")
+
+        args = [
+            "{}/scripts/config".format(self.source_dir),
+            "--file", self.get_cfgpath(),
+            "--{}".format(action),
+            option
+        ]
+        logging.info("%s config option '%s': %s", action, option, args)
+        subprocess.check_call(args)
+
     def prepare(self, clean=True):
         if (clean):
             args = self.make_argv_base + ["mrproper"]

--- a/tests/test_kernelbuilder.py
+++ b/tests/test_kernelbuilder.py
@@ -73,6 +73,32 @@ class KBuilderTest(unittest.TestCase):
                 mock.call(['make', '-C', self.tmpdir, 'mrproper']),
             )
 
+    def test_adjust_config_option(self):
+        """Ensure adjust_config_option() calls the correct commands."""
+        expected_args = [
+            "{}/scripts/config".format(self.tmpdir),
+            "--file",
+            "{}/.config".format(self.tmpdir),
+            "--disable",
+            "some_option"
+        ]
+
+        with self.ctx_check_call as m_check_call:
+            self.kbuilder.adjust_config_option('disable', 'some_option')
+            self.assertEqual(
+                m_check_call.mock_calls[0],
+                mock.call(expected_args)
+            )
+
+    def test_adjust_config_option_bogus(self):
+        """Ensure adjust_config_option() rejects bogus actions."""
+        with self.assertRaises(LookupError) as excmsg:
+            self.kbuilder.adjust_config_option('foo', 'some option')
+            self.assertEqual(
+                excmsg,
+                "Only 'enable' and 'disable' are supported."
+            )
+
     def test_mktgz_timeout(self):
         """
         Check if timeout error is raised when kernel building takes longer than


### PR DESCRIPTION
By adding a generic `adjust_config_option()` method to KernelBuilder, we can enable or disable config options during a build with a single method that is easy to test.