### PR TITLE
KernelBuilder: Generic source cleaning function

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -210,8 +210,12 @@ def cmd_build(cfg):
         enable_debuginfo=cfg.get('enable_debuginfo')
     )
 
+    # Clean the kernel source with 'make mrproper' if requested.
+    if cfg.get('wipe'):
+        builder.clean_kernel_source()
+
     try:
-        tgz = builder.mktgz(cfg.get('wipe'))
+        tgz = builder.mktgz()
     except Exception as e:
         save_state(cfg, {'buildlog': builder.buildlog})
         raise e

--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -64,12 +64,13 @@ class KernelBuilder(object):
         logging.info("%s config option '%s': %s", action, option, args)
         subprocess.check_call(args)
 
-    def prepare(self, clean=True):
-        if (clean):
-            args = self.make_argv_base + ["mrproper"]
-            logging.info("cleaning up tree: %s", args)
-            subprocess.check_call(args)
+    def clean_kernel_source(self):
+        """Clean the kernel source directory with 'make mrproper'."""
+        args = self.make_argv_base + ["mrproper"]
+        logging.info("cleaning up tree: %s", args)
+        subprocess.check_call(args)
 
+    def prepare(self):
         shutil.copyfile(self.basecfg, "%s/.config" % self.source_dir)
 
         # NOTE(mhayden): Building kernels with debuginfo can increase the
@@ -91,7 +92,7 @@ class KernelBuilder(object):
     def getrelease(self):
         krelease = None
         if not self._ready:
-            self.prepare(False)
+            self.prepare()
 
         args = self.make_argv_base + ["kernelrelease"]
         mk = subprocess.Popen(args, stdout=subprocess.PIPE)
@@ -107,12 +108,11 @@ class KernelBuilder(object):
 
         return krelease
 
-    def mktgz(self, clean=True, timeout=60 * 60 * 12):
+    def mktgz(self, timeout=60 * 60 * 12):
         """
         Build kernel and modules, after that, pack everything into a tarball.
 
         Args:
-            clean:      If it is True, run the `mrproper` target before build.
             timeout:    Max time in seconds will wait for build.
         Returns:
             The full path of the tarball generated.
@@ -126,7 +126,7 @@ class KernelBuilder(object):
         """
         fpath = None
         stdout_list = []
-        self.prepare(clean)
+        self.prepare()
 
         # Set up the arguments and options for the kernel build
         targz_pkg_argv = [

--- a/tests/test_kernelbuilder.py
+++ b/tests/test_kernelbuilder.py
@@ -53,24 +53,13 @@ class KBuilderTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
 
-    def test_mktgz_clean(self):
-        """
-        Check if `mrproper` target is called when `clean` is True and not
-        called when `clean` is False.
-        """
-        with self.ctx_popen, self.ctx_check_call as m_check_call:
-            self.assertRaises(Exception, self.kbuilder_mktgz_silent,
-                              clean=True)
+    def test_clean_kernel_source(self):
+        """Ensure clean_kernel_source() calls 'make mrproper'."""
+        with self.ctx_check_call as m_check_call:
+            self.kbuilder.clean_kernel_source()
             self.assertEqual(
                 m_check_call.mock_calls[0],
-                mock.call(['make', '-C', self.tmpdir, 'mrproper'])
-            )
-            m_check_call.reset_mock()
-            self.assertRaises(Exception, self.kbuilder_mktgz_silent,
-                              clean=False)
-            self.assertNotEqual(
-                m_check_call.mock_calls[0],
-                mock.call(['make', '-C', self.tmpdir, 'mrproper']),
+                mock.call(self.kbuilder.make_argv_base + ['mrproper'])
             )
 
     def test_adjust_config_option(self):


### PR DESCRIPTION
This PR pulls out the kernel source cleaning functionality into `KernelBuilder.clean_kernel_source()`. It makes testing easier and moves some logic out of various methods.