### PR TITLE
CircleCI: Switch to run flake8, pylint, and unittest via tox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,8 @@ defaults: &defaults
     - run:
         name: Run Python linters and tests
         command: |
-          flake8 --show-source .
-          pylint -d R0801 tests
-          python -m unittest discover tests
+          pip install tox coveralls
+          tox
     # TODO(mhayden): Add --depth support to skt and then let skt to the clone
     # rather than using the git command below.
     - run:

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@ envlist =
     pylint
 
 [testenv]
-passenv = TRAVIS TRAVIS_*
+passenv =
+    TRAVIS TRAVIS_*
+    CIRCLECI CIRCLE_* CI_PULL_REQUEST
 deps =
     coverage
     mock
@@ -16,14 +18,18 @@ commands =
     coveralls
 
 [testenv:flake8]
-passenv = CI TRAVIS TRAVIS_*
+passenv =
+    CI TRAVIS TRAVIS_*
+    CIRCLECI CIRCLE_*
 basepython =
     python2.7
 commands =
     flake8 --show-source .
 
 [testenv:pylint]
-passenv = CI TRAVIS TRAVIS_*
+passenv =
+    CI TRAVIS TRAVIS_*
+    CIRCLECI CIRCLE_*
 basepython =
     python2.7
 commands =


### PR DESCRIPTION
I make PR to switch to run `flake8`, `pylint`, and `unittest` via tox in `CircleCI`.