### PR TITLE
KernelBuilder: Add support for `make rh-configs` and `make tinyconfig`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,8 @@ defaults: &defaults
     - run:
         name: Test `skt build`
         command: |
-            make -C workdir tinyconfig
-            mv workdir/.config config
-            skt -vv --state -d workdir --rc sktrc build -c config
+            skt -vv --state -d workdir --rc sktrc build -c config \
+                --cfgtype tinyconfig
         working_directory: /tmp/skt_test
     - store_artifacts:
         path: /tmp/skt_test/workdir/*.log

--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -77,7 +77,15 @@ class KernelBuilder(object):
 
     def prepare_kernel_config(self):
         """Prepare the kernel config for the compile."""
-        shutil.copyfile(self.basecfg, "%s/.config" % self.source_dir)
+        if self.cfgtype == 'rh-configs':
+            # Build Red Hat configs and copy the correct one into place
+            self.make_redhat_config()
+        else:
+            # Copy the existing config file into place
+            shutil.copyfile(self.basecfg, "%s/.config" % self.source_dir)
+            args = self.make_argv_base + [self.cfgtype]
+            logging.info("prepare config: %s", args)
+            subprocess.check_call(args)
 
         # NOTE(mhayden): Building kernels with debuginfo can increase the
         # final kernel tarball size by 3-4x and can increase build time
@@ -87,14 +95,10 @@ class KernelBuilder(object):
         if not self.enable_debuginfo:
             self.adjust_config_option('disable', 'debug_info')
 
-        args = self.make_argv_base + [self.cfgtype]
-        logging.info("prepare config: %s", args)
-        subprocess.check_call(args)
         self._ready = 1
 
     def make_redhat_config(self):
         """Prepare the Red Hat kernel config files."""
-        # These configs build into /redhat/configs
         args = self.make_argv_base + ['rh-configs']
         logging.info("building Red Hat configs: %s", args)
         subprocess.check_call(args)

--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -70,7 +70,8 @@ class KernelBuilder(object):
         logging.info("cleaning up tree: %s", args)
         subprocess.check_call(args)
 
-    def prepare(self):
+    def prepare_kernel_config(self):
+        """Prepare the kernel config for the compile."""
         shutil.copyfile(self.basecfg, "%s/.config" % self.source_dir)
 
         # NOTE(mhayden): Building kernels with debuginfo can increase the
@@ -92,7 +93,7 @@ class KernelBuilder(object):
     def getrelease(self):
         krelease = None
         if not self._ready:
-            self.prepare()
+            self.prepare_kernel_config()
 
         args = self.make_argv_base + ["kernelrelease"]
         mk = subprocess.Popen(args, stdout=subprocess.PIPE)
@@ -126,7 +127,7 @@ class KernelBuilder(object):
         """
         fpath = None
         stdout_list = []
-        self.prepare()
+        self.prepare_kernel_config()
 
         # Set up the arguments and options for the kernel build
         targz_pkg_argv = [

--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -80,6 +80,9 @@ class KernelBuilder(object):
         if self.cfgtype == 'rh-configs':
             # Build Red Hat configs and copy the correct one into place
             self.make_redhat_config()
+        elif self.cfgtype == 'tinyconfig':
+            # Build an extremely small config file for quick testing
+            self.make_tinyconfig()
         else:
             # Copy the existing config file into place
             shutil.copyfile(self.basecfg, "%s/.config" % self.source_dir)
@@ -114,6 +117,12 @@ class KernelBuilder(object):
             config_filename[0],
             "{}/.config".format(self.source_dir)
         )
+
+    def make_tinyconfig(self):
+        """Make the smallest kernel config file possible for quick testing."""
+        args = self.make_argv_base + ['tinyconfig']
+        logging.info("building tinyconfig: %s", args)
+        subprocess.check_call(args)
 
     def get_cfgpath(self):
         return "%s/.config" % self.source_dir

--- a/tests/test_kernelbuilder.py
+++ b/tests/test_kernelbuilder.py
@@ -168,10 +168,9 @@ class KBuilderTest(unittest.TestCase):
         )
         self.assertEqual(kbuilder.extra_make_args, [extra_make_args_example])
 
-    def test_getrelease(self):
-        """Ensure get_release() handles a valid kernel version string"""
-        mock_prepare = mock.patch("skt.kernelbuilder.KernelBuilder.prepare")
-
+    @mock.patch("skt.kernelbuilder.KernelBuilder.prepare_kernel_config")
+    def test_getrelease(self, mock_prepare):
+        """Ensure get_release() handles a valid kernel version string."""
         kernel_version = '4.17.0-rc6+\n'
         mock_popen = self.ctx_popen
         self.m_popen.communicate = Mock(return_value=(kernel_version, None))
@@ -180,10 +179,9 @@ class KBuilderTest(unittest.TestCase):
             result = self.kbuilder.getrelease()
             self.assertEqual(kernel_version.strip(), result)
 
-    def test_getrelease_regex_fail(self):
-        """Ensure get_release() fails if the regex doesn't match"""
-        mock_prepare = mock.patch("skt.kernelbuilder.KernelBuilder.prepare")
-
+    @mock.patch("skt.kernelbuilder.KernelBuilder.prepare_kernel_config")
+    def test_getrelease_regex_fail(self, mock_prepare):
+        """Ensure get_release() fails if the regex doesn't match."""
         mock_popen = self.ctx_popen
         self.m_popen.communicate = Mock(return_value=('this_is_silly', None))
 


### PR DESCRIPTION
This PR builds support into KernelBuilder for handling Red Hat kernel configs as well as `tinyconfig` for very quick build tests.