### PR TITLE
Add rhconfig-glob option

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,11 +227,10 @@ Three kernel configuration file options are supported by `skt`:
 * Use a minimal configuration for a very small kernel: `--cfgtype tinyconfig`
 * Build kernel configuration files for Red Hat kernels: `--cfgtype rh-configs`
 
-When `rh-configs` is used, `skt` checks to see if the `ARCH` environment
-variable is set. If it is set, `skt` will select the appropriate kernel
-configuration file that matches the value of the `ARCH` variable. If it is
-not set, `skt` will check the native architecture of the current machine and
-use that architecture to select the correct kernel configuration file.
+Users must specify a filename glob using `--rhconfig-glob` with
+`--cfgtype rh-configs`. This allows `skt` to choose the correct kernel
+configuration file. As an example, `--rhconfig-glob x86_64` works for `x86_64`
+builds and `--rhconfig-glob ppc64le` works for POWER (little endian) systems.
 
 ### Publish
 

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -207,7 +207,8 @@ def cmd_build(cfg):
         basecfg=cfg.get('baseconfig'),
         cfgtype=cfg.get('cfgtype'),
         extra_make_args=cfg.get('makeopts'),
-        enable_debuginfo=cfg.get('enable_debuginfo')
+        enable_debuginfo=cfg.get('enable_debuginfo'),
+        rhconfig_glob=cfg.get('rhconfig_glob')
     )
 
     # Clean the kernel source with 'make mrproper' if requested.
@@ -541,6 +542,14 @@ def setup_parser():
         "--makeopts",
         type=str,
         help="Additional options to pass to make"
+    )
+    parser_build.add_argument(
+        "--rhconfig-glob",
+        type=str,
+        help=(
+            "Glob pattern to use when choosing the correct kernel config "
+            "file after running `make rh-configs`"
+        )
     )
 
     # These arguments apply to the 'publish' skt command

--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -29,7 +29,8 @@ from threading import Timer
 
 class KernelBuilder(object):
     def __init__(self, source_dir, basecfg, cfgtype=None,
-                 extra_make_args=None, enable_debuginfo=False):
+                 extra_make_args=None, enable_debuginfo=False,
+                 rhconfig_glob=None):
         self.source_dir = source_dir
         self.basecfg = basecfg
         self.cfgtype = cfgtype if cfgtype is not None else "olddefconfig"
@@ -38,6 +39,7 @@ class KernelBuilder(object):
         self.make_argv_base = ["make", "-C", self.source_dir]
         self.enable_debuginfo = enable_debuginfo
         self.build_arch = self.get_build_arch()
+        self.rhconfig_glob = rhconfig_glob
 
         # Split the extra make arguments provided by the user
         if extra_make_args:
@@ -112,7 +114,7 @@ class KernelBuilder(object):
         escaped_source_dir = self.glob_escape(self.source_dir)
         config = "{}/configs/kernel*{}.config".format(
             escaped_source_dir,
-            self.build_arch
+            self.rhconfig_glob
         )
         config_filename = glob.glob(config)
 


### PR DESCRIPTION
Checking for the `ARCH` environment variable does not work properly for
PPC since both big and little endian use `ARCH=powerpc`.

Users can provide a glob to match the config file of their choice when
using `cfgtype=rh-configs`.

Fixes #191.

Signed-off-by: Major Hayden <major@redhat.com>