### PR TITLE
Handle missing --states option

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -789,7 +789,8 @@ def load_config(args):
         cfg['tarpkg'] = full_path(cfg.get('tarpkg'))
 
     # Get absolute paths to state files for multireport
-    for idx, statefile_path in enumerate(cfg.get('states', [])):
+    # Handle "states" being None if none are specified
+    for idx, statefile_path in enumerate(cfg.get('states') or []):
         cfg['states'][idx] = full_path(statefile_path)
 
     return cfg


### PR DESCRIPTION
If no "--states" option is specified on the command line, cfg["states"]
gets set to None, instead of not being set. As a result iterating on it
with "enumerate" in load_config produces an exception. Switch to
checking the value for truth instead of existence to handle that case.