### PR TITLE
Unify "karch" and "arch" to "kernel_arch"

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -240,13 +240,13 @@ def cmd_build(cfg):
     shutil.copyfile(builder.get_cfgpath(), tconfig)
 
     krelease = builder.getrelease()
-    karch = builder.build_arch
+    kernel_arch = builder.build_arch
 
     save_state(cfg, {'tarpkg': ttgz,
                      'buildinfo': tbuildinfo,
                      'buildconf': tconfig,
                      'krelease': krelease,
-                     'karch': karch})
+                     'kernel_arch': kernel_arch})
 
 
 @junit
@@ -295,7 +295,7 @@ def cmd_run(cfg):
     runner = skt.runner.getrunner(*cfg.get('runner'))
     retcode = runner.run(cfg.get('buildurl'), cfg.get('krelease'),
                          cfg.get('wait'), uid=cfg.get('uid'),
-                         arch=cfg.get("karch"))
+                         arch=cfg.get("kernel_arch"))
 
     idx = 0
     for job in runner.jobs:

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -575,9 +575,9 @@ class Reporter(object):
                     self.multireport_failed = MULTI_MERGE
                     msg += self.getmergefailure()
 
-            marker = self.cfg.get('arch', str(idx + 1))
+            marker = self.cfg.get('kernel_arch', str(idx + 1))
             msg += ['\n##### These are the results for %s' %
-                    (marker + ' architecture' if self.cfg.get('arch')
+                    (marker + ' architecture' if self.cfg.get('kernel_arch')
                      else 'test set %s' % marker)]
             if not self.cfg.get('mergelog'):
                 msg += self.get_kernel_config(marker)


### PR DESCRIPTION
Multireport expected "arch" to be saved in the state file, but the
builder saves "karch". To avoid additional confusion with shortened
variable names, use "kernel_arch" in both cases.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>