### PR TITLE
KernelTree: Remove confusing error messages during testing

### DIFF
--- a/skt/kerneltree.py
+++ b/skt/kerneltree.py
@@ -76,12 +76,19 @@ class KernelTree(object):
         logging.info("work dir: %s", self.wdir)
 
     def git_cmd(self, *args, **kwargs):
-        args = list(["git", "--work-tree", self.wdir, "--git-dir",
-                     self.gdir]) + list(args)
-        logging.debug("executing: %s", " ".join(args))
-        subprocess.check_call(args,
-                              env=dict(os.environ, **{'LC_ALL': 'C'}),
-                              **kwargs)
+        """Run git commands."""
+        base_argv = ["git", "--work-tree", self.wdir, "--git-dir", self.gdir]
+        cmd_args = list(base_argv) + list(args)
+
+        logging.debug("executing: %s", " ".join(cmd_args))
+        output = subprocess.check_output(
+            cmd_args,
+            env=dict(os.environ, **{'LC_ALL': 'C'}),
+            stderr=subprocess.STDOUT,
+            **kwargs
+        )
+
+        return output
 
     def getpath(self):
         return self.wdir

--- a/skt/kerneltree.py
+++ b/skt/kerneltree.py
@@ -51,6 +51,7 @@ class KernelTree(object):
         self.ref = ref if ref is not None else "master"
         self.info = []
         self.mergelog = "%s/merge.log" % self.wdir
+        self.fetch_depth = fetch_depth
 
         try:
             os.mkdir(self.wdir)
@@ -61,8 +62,6 @@ class KernelTree(object):
             os.unlink(self.mergelog)
         except OSError:
             pass
-
-        self.fetch_depth = fetch_depth
 
         # Initialize the repository
         self.setup_repository()

--- a/skt/kerneltree.py
+++ b/skt/kerneltree.py
@@ -62,14 +62,10 @@ class KernelTree(object):
         except OSError:
             pass
 
-        self.git_cmd("init")
-
-        try:
-            self.git_cmd("remote", "set-url", "origin", self.uri)
-        except subprocess.CalledProcessError:
-            self.git_cmd("remote", "add", "origin", self.uri)
-
         self.fetch_depth = fetch_depth
+
+        # Initialize the repository
+        self.setup_repository()
 
         logging.info("base repo url: %s", self.uri)
         logging.info("base ref: %s", self.ref)
@@ -92,6 +88,20 @@ class KernelTree(object):
 
     def getpath(self):
         return self.wdir
+
+    def setup_repository(self):
+        """Initialize the repo and set the origin."""
+        self.git_cmd("init")
+
+        # Does the repo have an origin set?
+        if 'origin' in self.git_cmd("remote").split('\n'):
+            # Ensure the origin is set to the correct URL
+            logging.debug("Setting URL for remote 'origin': %s" % self.uri)
+            self.git_cmd("remote", "set-url", "origin", self.uri)
+        else:
+            # Add the origin remote
+            logging.debug("Adding missing remote 'origin': %s" % self.uri)
+            self.git_cmd("remote", "add", "origin", self.uri)
 
     def dumpinfo(self, fname='buildinfo.csv'):
         """

--- a/tests/test_kerneltree.py
+++ b/tests/test_kerneltree.py
@@ -179,6 +179,15 @@ class KernelTreeTest(unittest.TestCase):
 
         self.assertEqual('example.com_', result)
 
+    @mock.patch('logging.debug')
+    @mock.patch('subprocess.check_output')
+    def test_git_cmd(self, mock_check_output, mock_logging):
+        """Ensure git_cmd() works."""
+        mock_check_output.return_value = "Test return value"
+        output = self.kerneltree.git_cmd("status")
+        self.assertEqual("Test return value", output)
+        mock_logging.assert_called_once()
+
     def test_merge_git_ref(self):
         """Ensure merge_git_ref() returns a proper tuple."""
         mock_git_cmd = mock.patch('skt.kerneltree.KernelTree.git_cmd')

--- a/tests/test_kerneltree.py
+++ b/tests/test_kerneltree.py
@@ -290,3 +290,17 @@ class KernelTreeTest(unittest.TestCase):
         """Ensure merge_patch_file() fails when a patch is missing."""
         with self.assertRaises(Exception):
             self.kerneltree.merge_patch_file('patch_does_not_exist')
+
+    @mock.patch('skt.kerneltree.KernelTree.git_cmd')
+    def test_setup_repository_add(self, mock_git_cmd):
+        """Ensure setup_repository() adds the origin URL."""
+        mock_git_cmd.side_effect = [True, "remote1\nremote2\remote3\n", True]
+        self.kerneltree.setup_repository()
+        self.assertIn('add', mock_git_cmd.call_args_list[2][0])
+
+    @mock.patch('skt.kerneltree.KernelTree.git_cmd')
+    def test_setup_repository_set(self, mock_git_cmd):
+        """Ensure setup_repository() sets the origin URL when it exists."""
+        mock_git_cmd.side_effect = [True, "remote1\nremote2\norigin\n", True]
+        self.kerneltree.setup_repository()
+        self.assertIn('set-url', mock_git_cmd.call_args_list[2][0])

--- a/tests/test_kerneltree.py
+++ b/tests/test_kerneltree.py
@@ -162,7 +162,8 @@ class KernelTreeTest(unittest.TestCase):
 
         self.assertEqual(result, 'http://example.com/')
 
-    def test_get_remote_name(self):
+    @mock.patch('logging.warning')
+    def test_get_remote_name(self, mock_logging):
         """
         Ensure get_remote_name() handles remote names from get_remote_url().
         """
@@ -178,6 +179,8 @@ class KernelTreeTest(unittest.TestCase):
             result = self.kerneltree.get_remote_name("http://example.com/")
 
         self.assertEqual('example.com_', result)
+
+        mock_logging.assert_called_once()
 
     @mock.patch('logging.debug')
     @mock.patch('subprocess.check_output')
@@ -201,11 +204,12 @@ class KernelTreeTest(unittest.TestCase):
 
         self.assertTupleEqual((0, 'abcdef'), result)
 
+    @mock.patch('logging.warning')
     @mock.patch('skt.kerneltree.KernelTree.get_remote_name')
     @mock.patch('skt.kerneltree.KernelTree.get_commit_hash')
     @mock.patch('skt.kerneltree.KernelTree.git_cmd')
     def test_merge_git_ref_failure(self, mock_git_cmd, mock_get_commit_hash,
-                                   mock_get_remote_name):
+                                   mock_get_remote_name, mock_logging):
         """Ensure merge_git_ref() fails properly when remote add fails."""
         mock_get_remote_name.return_value = "origin"
         mock_git_cmd.side_effect = [
@@ -219,6 +223,8 @@ class KernelTreeTest(unittest.TestCase):
         result = self.kerneltree.merge_git_ref('http://example.com')
 
         self.assertTupleEqual((1, None), result)
+
+        mock_logging.assert_called_once()
 
     def test_merge_pw_patch(self):
         """Ensure merge_patchwork_patch() handles patches properly."""

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -204,8 +204,9 @@ class TestRunner(unittest.TestCase):
         result = self.myrunner.getresults("J:00001")
         self.assertEqual(result, 0)
 
+    @mock.patch('logging.warning')
     @mock.patch('skt.runner.BeakerRunner.getresultstree')
-    def test_getresults_failure(self, mock_getresultstree):
+    def test_getresults_failure(self, mock_getresultstree, mock_logging):
         """Ensure getresults() handles a job failure"""
         # Mock up a beaker XML reply
         beaker_xml = misc.get_asset_content('beaker_fail_results.xml')
@@ -231,6 +232,7 @@ class TestRunner(unittest.TestCase):
         }
         result = self.myrunner.getresults("J:00001")
         self.assertEqual(result, 1)
+        mock_logging.assert_called()
 
     def test_recipe_to_job(self):
         """Ensure recipe_to_job() works"""

--- a/tests/test_state_file.py
+++ b/tests/test_state_file.py
@@ -56,12 +56,15 @@ class TestStateFile(unittest.TestCase):
         state_file.destroy(self.cfg)
         self.assertFalse(os.path.isfile(self.cfg['state']))
 
+    @mock.patch('logging.error')
     @mock.patch('os.unlink', side_effect=exception_maker)
-    def test_destroy_state_file_failure(self, mockobj):
+    def test_destroy_state_file_failure(self, mock_unlink, mock_logging):
         """Ensure destroy() fails when state file cannot be deleted."""
         # pylint: disable=W0613
         with self.assertRaises(IOError):
             state_file.destroy(self.cfg)
+
+        mock_logging.assert_called_once()
 
     def test_read_state_file(self):
         """Ensure read() reads the state file."""
@@ -74,12 +77,15 @@ class TestStateFile(unittest.TestCase):
         test_yaml = state_file.read(self.cfg)
         self.assertDictEqual(test_yaml, {})
 
+    @mock.patch('logging.error')
     @mock.patch('yaml.load', side_effect=exception_maker)
-    def test_read_state_file_failure(self, mockobj):
+    def test_read_state_file_failure(self, mock_yaml, mock_logging):
         """Ensure read() fails when state file is unreadable."""
         # pylint: disable=W0613
         with self.assertRaises(IOError):
             state_file.read(self.cfg)
+
+        mock_logging.assert_called_once()
 
     def test_update_state_file(self):
         """Ensure update() updates the state file."""
@@ -96,11 +102,14 @@ class TestStateFile(unittest.TestCase):
         }
         self.assertDictEqual(state_data, expected_dict)
 
+    @mock.patch('logging.error')
     @mock.patch('yaml.dump', side_effect=exception_maker)
-    def test_update_state_file_failure(self, mockobj):
+    def test_update_state_file_failure(self, mock_yaml, mock_logging):
         """Ensure update() fails when the state file cannot be updated."""
         # pylint: disable=W0613
         # Write some new state
         new_state = {'foo2': 'bar2'}
         with self.assertRaises(IOError):
             state_file.update(self.cfg, new_state)
+
+        mock_logging.assert_called_once()


### PR DESCRIPTION
This PR fixes #124 by moving the `git init` and remote setting logic into its own method. This allows it to be tested much more easily and avoids confusing messages in the testing output.