### PR TITLE
Remove tests directory from coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     mock
     coveralls
 commands =
-    coverage run --branch --source=skt,tests -m unittest discover tests
+    coverage run --branch --source=skt -m unittest discover tests
     coverage report -m
     coveralls
 


### PR DESCRIPTION
The test coverage percentage is higher than it should be. This is
because the tests themselves are being included in the results.

Fixes #203.

Signed-off-by: Major Hayden <major@redhat.com>