### PR TITLE
junit:  Create directory if it doesn't exist

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -793,6 +793,12 @@ def load_config(args):
     for idx, statefile_path in enumerate(cfg.get('states') or []):
         cfg['states'][idx] = full_path(statefile_path)
 
+    if cfg.get('junit'):
+        try:
+            os.mkdir(full_path(cfg.get('junit')))
+        except OSError:
+            pass
+
     return cfg
 
 


### PR DESCRIPTION
This day and age, we shouldn't expect the user to create a directory
ahead of time.  Try and create it early on.

This also fixes the problem of waiting until the end of the command to find
out that the user forgot that simple step.