### PR TITLE
Remove update_mergedata from the wrong place

### DIFF
--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -707,7 +707,6 @@ class MailReporter(Reporter):
         super(MailReporter, self).__init__(cfg)
 
     def report(self):
-        self.update_mergedata()
         msg = MIMEMultipart()
         msg['Subject'] = self.subject
         msg['To'] = ', '.join(self.mailto)


### PR DESCRIPTION
The call was copied into the "else" statement but wasn't removed from
it's original place.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>