### PR TITLE
Add support for remote smtp url

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -649,6 +649,11 @@ def setup_parser():
         type=str,
         help='Path to a state file to include in the report'
     )
+    parser_report.add_argument(
+        "--smtp-url",
+        type=str,
+        help='Use smtp url instead of localhost to send mail',
+    )
     parser_report.set_defaults(func=cmd_report)
     parser_report.set_defaults(_name="report")
 

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -690,6 +690,8 @@ class MailReporter(Reporter):
         self.headers = [headers.strip() for headers in
                         cfg['reporter']['mail_header']]
         self.subject = cfg['reporter']['mail_subject']
+        self.smtp_url = cfg.get('smtp_url') or 'localhost'
+
         super(MailReporter, self).__init__(cfg)
 
     def report(self):
@@ -734,6 +736,6 @@ class MailReporter(Reporter):
 
             msg.attach(tmp)
 
-        s = smtplib.SMTP('localhost')
+        s = smtplib.SMTP(self.smtp_url)
         s.sendmail(self.mailfrom, self.mailto, msg.as_string())
         s.quit()


### PR DESCRIPTION
Some of us suck at setting up a local smtp server.  Make
it easy by allowing one to add an entry in sktrc to point
to a remote server.  Use the 'smtp_url' entry.

    [config]
    smtp_url = smtp.example.com

Otherwise if the above is not defined (common case), it defaults
to 'localhost'.

Only used by the 'reporter' command.