### PR TITLE
Fix detection of mail reporter options

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -873,7 +873,8 @@ def check_args(parser, args):
 
         # No mail-related options should be provided for StdioReporter
         if (args.type == 'stdio'
-           and [x for x in dir(args) if x.startswith('mail')]):
+                and any([getattr(args, x)
+                         for x in dir(args) if x.startswith('mail')])):
             parser.error(
                 'the stdio reporter was selected but arguments for the mail'
                 'reporter were provided'


### PR DESCRIPTION
We should be checking the value, not existence -- the attributes exist
every time.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>