### PR TITLE
merge: Convert multi-value options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## June 2018
 
+* Arguments for `skt merge` should now be used multiple times instead of
+  supplying multiple values for each option. This affects the following
+  arguments:
+
+  * `--patch` (formerly `--patchlist`)
+  * `--pw`
+  * `--merge-ref`
+
+  Example: `skt merge --pw URL1 --pw URL2 --pw URL3`
+
 * Arguments for reporter are now explicitly defined and JSON strings are no
   longer required. Users can specify the following arguments:
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ To apply a local patch run:
     skt --rc <SKTRC> --state --workdir <WORKDIR> -vv \
         merge --baserepo <REPO_URL> \
               --ref <REPO_REF> \
-              --patchlist <PATH_TO_PATCH>
+              --patch <PATH_TO_PATCH>
 
 Here, `<PATH_TO_PATCH>` would be the patch file.
 E.g. to apply a particular patch to a particular, known-good commit from the
@@ -179,7 +179,7 @@ E.g. to apply a particular patch to a particular, known-good commit from the
     skt --rc skt-rc --state --workdir skt-workdir -vv \
         merge --baserepo git://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git \
               --ref a870a02cc963de35452bbed932560ed69725c4f2 \
-              --patchlist net-next-cxgb4-notify-fatal-error-to-uld-drivers.patch
+              --patch net-next-cxgb4-notify-fatal-error-to-uld-drivers.patch
 
 #### Faster clones
 

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -159,10 +159,10 @@ def cmd_merge(cfg):
             if retcode:
                 return
 
-        if cfg.get('patchlist'):
+        if cfg.get('patch'):
             utypes.append("[local patch]")
             idx = 0
-            for patch in cfg.get('patchlist'):
+            for patch in cfg.get('patch'):
                 patch = os.path.abspath(patch)
                 save_state(cfg, {'localpatch_%02d' % idx: patch})
                 ktree.merge_patch_file(patch)
@@ -503,23 +503,31 @@ def setup_parser():
         help="Base repo ref to which patches are applied (default: master)"
     )
     parser_merge.add_argument(
-        "--patchlist",
+        "--patch",
         type=str,
-        nargs="+",
-        help="Paths to each local patch to apply (space delimited)"
+        action='append',
+        help=(
+            "Path to each local patch to apply "
+            "(use multiple times for multiple patches)"
+        )
     )
     parser_merge.add_argument(
         "--pw",
         type=str,
-        nargs="+",
-        help="URLs to each Patchwork patch to apply (space delimited)"
+        action='append',
+        help=(
+            "URL to Patchwork patch to apply"
+            "(use multiple times for multiple patches)"
+        )
     )
     parser_merge.add_argument(
         "-m",
         "--merge-ref",
-        nargs="+",
-        help="Merge ref format: 'url [ref]'",
-        action="append"
+        action='append',
+        help=(
+            "Merge ref format: 'url [ref]'",
+            "(use multiple times for multiple merge refs)"
+        ),
     )
     parser_merge.add_argument(
         "--fetch-depth",


### PR DESCRIPTION
Convert multi-value options to arguments that can be repeated.
This improves readability on the command line.

Fixes #227.

Signed-off-by: Major Hayden <major@redhat.com>