### PR TITLE
PR to simplify path of patchlist in cmd_merge

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -163,8 +163,9 @@ def cmd_merge(cfg):
             utypes.append("[local patch]")
             idx = 0
             for patch in cfg.get('patchlist'):
+                patch = os.path.abspath(patch)
                 save_state(cfg, {'localpatch_%02d' % idx: patch})
-                ktree.merge_patch_file(os.path.abspath(patch))
+                ktree.merge_patch_file(patch)
                 idx += 1
 
         if cfg.get('pw'):


### PR DESCRIPTION
I make PR to simplify path of `patchlist` in cmd_merge. In some cases, the path might contain multiple slashes `/` together.  Such as `/skt-workdir//example.patch/`.
In this case, it should ignore redundant slashes and return `/skt-workdir/example.patch`. It will remove redundant the slashes of `localpatch` in `skt-rc`.