### PR TITLE
Use the top hash to mark buildhead

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -184,7 +184,7 @@ def cmd_merge(cfg):
 
     kpath = ktree.getpath()
     buildinfo = ktree.dumpinfo()
-    buildhead = ktree.get_commit_hash()
+    buildhead = ktree.git_cmd('show', '--format=%H', '-s')
 
     save_state(cfg, {'workdir': kpath,
                      'buildinfo': buildinfo,


### PR DESCRIPTION
If a ref is specified (eg. we want to apply patches on top of working
baseline), this ref is returned by kerneltree.get_commit_hash(). This is
totally fine for most of the usecases, but not for the buildhead, which
should be different based on the patches applied on top. If more builds
with different patches, on top of same non-master baseline are done,
they get overwritten because they use same names for build artifacts.

Fix this problem by always retrieving the top commit from the repo for
buildhead.

Fixes #242

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>