### PR TITLE
Wrap git_cmd exception output

### DIFF
--- a/skt/kerneltree.py
+++ b/skt/kerneltree.py
@@ -111,7 +111,11 @@ class KernelTree(object):
         Returns:
             Git command output.
         """
-        return self.git_cmd_call(subprocess.check_output, *args, **kwargs)
+        try:
+            return self.git_cmd_call(subprocess.check_output, *args, **kwargs)
+        except subprocess.CalledProcessError as exc:
+            logging.debug(exc.output)
+            raise(exc)
 
     def git_cmd_pipe(self, input, *args, **kwargs):
         """


### PR DESCRIPTION
The actual error message from git is pretty useful for debug purposes,
so let's log it. Re-raise the exception if it occurred so the caller can
catch it if it's expected, same as before.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>