### PR TITLE
Update comments in patch subject retrieval

### DIFF
--- a/skt/__init__.py
+++ b/skt/__init__.py
@@ -67,11 +67,7 @@ def get_patch_name(content):
         # instead of it
         return '<SUBJECT MISSING>'
 
-    # skt's custom CSV parsing doesn't understand multiline values, until we
-    # switch to a proper parser we need a temporary fix. Use separate
-    # replacements to handle Windows / *nix endlines and mboxes which contain
-    # '\n' and a space instead of '\n\t' as well.
-    # Tracking issue: https://github.com/RH-FMK/skt/issues/119
+    # Remove header folding
     subject = subject.replace('\n', ' ').replace('\t', '').replace('\r', '')
 
     try:


### PR DESCRIPTION
While the original comment is true, we agreed that it would be better to
remove newlines and tabs created by header folding anyways. Update the
comment to reflect on this decision to avoid making it looks like a bug
workaround.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>