### PR TITLE
Fix placing of binary operators

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -508,22 +508,22 @@ def setup_parser():
         "--patch",
         type=str,
         action='append',
-        help="Path to a local patch to apply " +
-             "(use multiple times for multiple patches)"
+        help="Path to a local patch to apply "
+             + "(use multiple times for multiple patches)"
     )
     parser_merge.add_argument(
         "--pw",
         type=str,
         action='append',
-        help="URL to Patchwork patch to apply " +
-             "(use multiple times for multiple patches)"
+        help="URL to Patchwork patch to apply "
+             + "(use multiple times for multiple patches)"
     )
     parser_merge.add_argument(
         "-m",
         "--merge-ref",
         action='append',
-        help="Merge ref format: 'url [ref]' " +
-             "(use multiple times for multiple merge refs)"
+        help="Merge ref format: 'url [ref]' "
+             + "(use multiple times for multiple merge refs)"
     )
     parser_merge.add_argument(
         "--fetch-depth",


### PR DESCRIPTION
PEP8 encourages writing binary operators on the beginning of
continuation line, not end of the previous one (so one can easily see
what's going on). pycodestyle by default doesn't check for these.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>