### PR TITLE
Include original trace of the exceptions

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -175,9 +175,10 @@ def cmd_merge(cfg):
                 save_state(cfg, {'patchwork_%02d' % idx: patch})
                 ktree.merge_patchwork_patch(patch)
                 idx += 1
-    except Exception as e:
+    except Exception:
         save_state(cfg, {'mergelog': ktree.mergelog})
-        raise e
+        (exc, exc_type, trace) = sys.exc_info()
+        raise exc, exc_type, trace
 
     uid = "[baseline]"
     if utypes:
@@ -219,9 +220,10 @@ def cmd_build(cfg):
 
     try:
         tgz = builder.mktgz()
-    except Exception as e:
+    except Exception:
         save_state(cfg, {'buildlog': builder.buildlog})
-        raise e
+        (exc, exc_type, trace) = sys.exc_info()
+        raise exc, exc_type, trace
 
     if cfg.get('buildhead'):
         ttgz = "%s.tar.gz" % cfg.get('buildhead')


### PR DESCRIPTION
When the exceptions are re-raised, the original trace is overwritten by
the newly raised one, making the original problem harder to find.
Retrieve the original trace and raise that instead.

Fixes #196

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>