### PR TITLE
Test_kerneltree: Remove pylint: disable= too-many-public-methods 

### DIFF
--- a/tests/test_kerneltree.py
+++ b/tests/test_kerneltree.py
@@ -32,7 +32,6 @@ def make_process_exception(*args, **kwargs):
 
 
 class KernelTreeTest(unittest.TestCase):
-    # (Too many public methods) pylint: disable=too-many-public-methods
     """Test cases for KernelBuilder class."""
 
     def setUp(self):


### PR DESCRIPTION
I make PR to remove pylint: disable= too-many-public-methods.
Although I mark the private and protected methods in Runner, I cannot remove this disable in `test_runner`. 
```
************* Module tests.test_runner
R: 35, 0: Too many public methods (22/20) (too-many-public-methods)
```