### PR TITLE
Switch to use rpartition function instead of split function

### DIFF
--- a/skt/kerneltree.py
+++ b/skt/kerneltree.py
@@ -240,7 +240,7 @@ class KernelTree(object):
         Returns:
             Full hash of the last commit.
         """
-        dstref = "refs/remotes/origin/%s" % (self.ref.split('/')[-1])
+        dstref = "refs/remotes/origin/%s" % (self.ref.rpartition('/')[2])
         logging.info("fetching base repo")
         git_fetch_args = [
             "fetch", "origin",
@@ -286,9 +286,11 @@ class KernelTree(object):
         return rurl
 
     def __get_remote_name(self, uri):
-        remote_name = (uri.split('/')[-1].replace('.git', '')
-                       if not uri.endswith('/')
-                       else uri.split('/')[-2].replace('.git', ''))
+        if not uri.endswith('/'):
+            remote_name = uri.rpartition('/')[2].replace('.git', '')
+        else:
+            remote_name = uri.rstrip('/').rpartition('/')[2].replace('.git',
+                                                                     '')
         while self.__get_remote_url(remote_name) == uri:
             logging.warning(
                 "remote '%s' already exists with a different uri, adding '_'",
@@ -308,7 +310,7 @@ class KernelTree(object):
         except subprocess.CalledProcessError:
             pass
 
-        dstref = "refs/remotes/%s/%s" % (remote_name, ref.split('/')[-1])
+        dstref = "refs/remotes/%s/%s" % (remote_name, ref.rpartition('/')[2])
         logging.info("fetching %s", dstref)
         self.__git_cmd("fetch", remote_name,
                        "+%s:%s" % (ref, dstref))

--- a/skt/runner.py
+++ b/skt/runner.py
@@ -487,7 +487,7 @@ class BeakerRunner(Runner):
         self.watchlist = set()
 
         # FIXME Pass or retrieve this explicitly
-        uid += " %s" % url.split('/')[-1]
+        uid += " %s" % url.rpartition('/')[2]
 
         if host is None:
             hostname = ""


### PR DESCRIPTION
I make PR to switch to use `rpartition` function instead of `split` function for clear. 
In order to get the last part in a path, instead of using split: `split('/')[-1]`, Python supports the `rpartition(sep)` function. It splits the string at the last occurrence of sep, and returns a 3-tupple containing the part before the separator, the separator itself, and the part after the separator.