### PR TITLE
Raise exception if file to report doesn't exist

### DIFF
--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -65,7 +65,8 @@ def load_state_cfg(statefile):
     """
     cfg = {}
     state_to_report = ConfigParser.ConfigParser()
-    state_to_report.read(statefile)
+    with open(statefile, 'r') as fileh:
+        state_to_report.readfp(fileh)
 
     # FIXME This can be simplified or removed after configuration and
     # state split


### PR DESCRIPTION
ConfigParser.read() returns a list of successfully parsed filenames.
This can be checked and exception about nonexistent file can be raised
if it's empty.

This makes it clear where the underlying problem is, instead of failing
when retrieving state section and producing cryptic exceptions.

Fixes #274

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>