### PR TITLE
Don't try to report aborted jobs

### DIFF
--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -469,12 +469,9 @@ class Reporter(object):
 
         minfo = {"short": {}, "long": {}}
         jidx = 1
-        for jobid in job_list:
-            for (recipe, rdata) in vresults[jobid].iteritems():
-                if recipe == "result":
-                    continue
-
-                (res, system, clogurl, slshwurl, _) = rdata
+        for jobid, values in vresults.items():
+            for recipe in [key for key in values if key.startswith('R:')]:
+                (res, system, clogurl, slshwurl, _) = values[recipe]
 
                 clog = ConsoleLog(self.cfg.get("krelease"), clogurl)
                 if not clog.data and res != 'Pass':

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -526,6 +526,10 @@ class Reporter(object):
                 result.append('')
                 jidx += 1
 
+            if self.multireport and self.cfg.get('retcode') != '0' and \
+                    self.multireport_failed == MULTI_PASS:
+                self.multireport_failed = MULTI_TEST
+
         return result
 
     def _getreport(self):
@@ -624,9 +628,6 @@ class Reporter(object):
                     results += self.__getjobresults()
 
             results.append('\n')
-
-            if self.cfg.get('retcode') != '0':
-                self.multireport_failed = MULTI_TEST
 
         results += ['Please reply to this email if you find an issue with our '
                     'testing process,',

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -470,6 +470,12 @@ class Reporter(object):
         minfo = {"short": {}, "long": {}}
         jidx = 1
         for jobid, values in vresults.items():
+            job_result = values.get('result')
+            job_status = values.get('status')
+            if job_result == 'Warn' and job_status == 'Aborted':
+                logging.info('Skipping aborted job %s', jobid)
+                continue
+
             for recipe in [key for key in values if key.startswith('R:')]:
                 (res, system, clogurl, slshwurl, _) = values[recipe]
 

--- a/skt/runner.py
+++ b/skt/runner.py
@@ -326,10 +326,10 @@ class BeakerRunner(Runner):
         fhosts = set()
         tfailures = 0
 
-        if jobid is not None:
+        if jobid:
             (ret, _) = self.__jobresult(jobid)
 
-        if jobid is None or ret != 0:
+        if not jobid or ret != 0:
             if self.failures:
                 all_aborted = all([data[1] == ('Warn', 'Aborted')
                                    for data in self.failures.values()])

--- a/skt/runner.py
+++ b/skt/runner.py
@@ -202,6 +202,7 @@ class BeakerRunner(Runner):
             root = self.getresultstree(jobid, True)
 
             result[jobid]['result'] = root.attrib.get("result")
+            result[jobid]['status'] = root.attrib.get('status')
 
             for recipe in root.findall("recipeSet/recipe"):
                 rid = "R:%s" % recipe.attrib.get("id")

--- a/skt/runner.py
+++ b/skt/runner.py
@@ -367,17 +367,18 @@ class BeakerRunner(Runner):
             for (cid, reschedule, origin) in self.watchlist.copy():
                 root = self.getresultstree(cid)
 
-                if root.attrib.get("status") in ["Completed", "Aborted",
-                                                 "Cancelled"]:
+                result = root.attrib.get('result')
+                status = root.attrib.get('status')
+                if status in ['Completed', 'Aborted', 'Cancelled']:
                     logging.info("%s status changed to '%s', "
                                  "removing from watchlist",
                                  cid, root.attrib.get("status"))
                     self.watchlist.remove((cid, reschedule, origin))
 
-                    if root.attrib.get("status") == "Cancelled":
+                    if status == 'Cancelled':
                         continue
 
-                    if root.attrib.get("result") != "Pass":
+                    if result != 'Pass':
                         tinst = root.find(
                             ".//task[@name='/distribution/install']"
                         )
@@ -399,13 +400,11 @@ class BeakerRunner(Runner):
                             self.failures[origin][0].append(root.attrib.get(
                                 "system"
                             ))
-                            self.failures[origin][1].add(root.attrib.get(
-                                "result"
-                            ))
+                            self.failures[origin][1].add(result)
 
                             if reschedule:
                                 logging.info("%s -> '%s', resubmitting",
-                                             cid, root.attrib.get("result"))
+                                             cid, result)
 
                                 newjob = self.__recipe_to_job(root, False)
                                 newjobid = self.__jobsubmit(etree.tostring(

--- a/skt/runner.py
+++ b/skt/runner.py
@@ -282,16 +282,31 @@ class BeakerRunner(Runner):
         return max(set(fhosts), key=fhosts.count)
 
     def __jobresult(self, jobid):
-        ret = 0
+        """
+        Get results for a specific job.
+
+        Args:
+            jobid: A Beaker job ID, in 'J:<id>' format.
+
+        Returns:
+            A tuple (ret, result), where ret is 0 if the job ended with Pass,
+            1 if a test failure occurred and 2 if it aborted (infrastructure
+            failure); and result is the job result itself.
+        """
         result = None
 
-        if jobid is not None:
-            root = self.getresultstree(jobid)
-            result = root.attrib.get("result")
+        root = self.getresultstree(jobid)
+        result = root.attrib.get("result")
+        status = root.attrib.get('status')
 
-            if result != "Pass":
-                ret = 1
-            logging.info("job result: %s [%d]", result, ret)
+        if result == "Pass":
+            ret = 0
+        elif result == 'Warn' and status == 'Aborted':
+            ret = 2
+        else:
+            ret = 1
+
+        logging.info("job result: %s [%d]", result, ret)
 
         return (ret, result)
 

--- a/skt/runner.py
+++ b/skt/runner.py
@@ -380,7 +380,7 @@ class BeakerRunner(Runner):
 
                     if result != 'Pass':
                         tinst = root.find(
-                            ".//task[@name='/distribution/install']"
+                            ".//task[@name='/distribution/kpkginstall']"
                         )
                         if tinst is not None and \
                                 tinst.attrib.get("result") != "Pass":

--- a/tests/assets/beaker_results.xml
+++ b/tests/assets/beaker_results.xml
@@ -1,4 +1,4 @@
-<xml result='Pass'>
+<xml result='Pass' status='Completed'>
   <whiteboard>
     skt 4.17.0-rc1+ 1234567890.tar.gz [noavc] [noselinux]
   </whiteboard>

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -221,21 +221,21 @@ class TestRunner(unittest.TestCase):
 
         # Ensure that the failure loop hits 'continue'
         self.myrunner.failures = {
-            'test': ['A', None, 4]
+            'test': ['A', set(), 4]
         }
         result = self.myrunner._BeakerRunner__getresults("J:00001")
         self.assertEqual(result, 1)
 
         # Go through the failure loop with one failed host
         self.myrunner.failures = {
-            'test': [['A'], ['a'], 1]
+            'test': [['A'], set([('result', 'status')]), 1]
         }
         result = self.myrunner._BeakerRunner__getresults("J:00001")
         self.assertEqual(result, 1)
 
         # Go through the failure loop with multiple failed hosts
         self.myrunner.failures = {
-            'test': [['A', 'B'], ['a'], 1]
+            'test': [['A', 'B'], set([('result', 'status')]), 1]
         }
         result = self.myrunner._BeakerRunner__getresults("J:00001")
         self.assertEqual(result, 1)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -166,7 +166,8 @@ class TestRunner(unittest.TestCase):
                     'http://example.com/machinedesc.log',
                     'http://example.com/lshw.log'
                 ),
-                'result': 'Pass'
+                'result': 'Pass',
+                'status': 'Completed'
             }
         }
         self.assertDictEqual(result, expected_result)


### PR DESCRIPTION
If the test job aborts, there are no results to report. Skip test
reporting if all of the jobs aborted, and skip reporting of the
actual aborted jobs, instead of getting an exception on trying to
report nonexistent results.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>