### PR TITLE
Remove Shebang header

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python2
-
 # Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted
 # material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General

--- a/skt/state_file.py
+++ b/skt/state_file.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python2
-
 # Copyright (c) 2017 Red Hat, Inc. All rights reserved. This copyrighted
 # material is made available to anyone wishing to use, modify, copy, or
 # redistribute it subject to the terms and conditions of the GNU General


### PR DESCRIPTION
I make PR to remove `Shebang` header. Because skt is not executed by a script, Shebang header should be removed.