### PR TITLE
Exchange LTP logs

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -257,19 +257,20 @@ class BeakerRunner(Runner):
             if ltp_node is None:
                 continue
 
+            ltp_results = ltp_node.find(
+                "results/result[@path='RHELKT1LITE.FILTERED']/logs/"
+                "log[@name='resultoutputfile.log']"
+            )
+            if ltp_results is not None:
+                ltp_results = ltp_results.attrib.get('href')
+
             run_log = ltp_node.find(
                 "logs/log[@name='RHELKT1LITE.FILTERED.run.log']"
             )
             if run_log is not None:
                 run_log = run_log.attrib.get('href')
 
-            ltp_results = ltp_node.find(
-                "results/result/logs/log[@name='resultoutputfile.log']"
-            )
-            if ltp_results is not None:
-                ltp_results = ltp_results.attrib.get('href')
-
-            ltp_logs[recipe_id] = (run_log, ltp_results)
+            ltp_logs[recipe_id] = (ltp_results, run_log)
 
         return ltp_logs
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -761,7 +761,7 @@ class TestStdioReporter(unittest.TestCase):
             'https://beaker.example.com/recipes/5290731/tasks/74019102/'
             'logs/RHELKT1LITE.FILTERED.run.log',
             'https://beaker.example.com/recipes/5290731/tasks/74019102/'
-            'results/358724407/logs/resultoutputfile.log',
+            'results/358727247/logs/resultoutputfile.log',
         ]
         for required_string in required_strings:
             self.assertIn(required_string, report)


### PR DESCRIPTION
Exchange the LTP install log for the summary of run tests, and switch
the order of the logs. This way, the first linked log contains the test
summary where the failed tests can be found, and the second one the
details of test runs (which can be easily searched for the names of the
failed tests from the first log).

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>