### PR TITLE
BeakerRunner.dumpjunitresult() accept output filename

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -437,7 +437,9 @@ def cmd_run(cfg):
     for job in runner.jobs:
         if cfg.get('wait') and cfg.get('junit'):
             try:
-                runner.dumpjunitresults(job, cfg.get('junit'))
+                fname = "%s/%s.xml" % (cfg.get('junit'),
+                                       job.replace(":", "_").lower())
+                runner.dumpjunitresults(job, fname)
             except Exception as exc:
                 logging.error(exc)
                 retcode = SKT_ERROR

--- a/skt/runner.py
+++ b/skt/runner.py
@@ -122,18 +122,17 @@ class BeakerRunner(Runner):
         (stdout, _) = bkr.communicate()
         return etree.fromstring(stdout)
 
-    def dumpjunitresults(self, jobid, junit):
+    def dumpjunitresults(self, jobid, fname):
         """
         Retrieve junit XML from beaker and write it to a file
 
         Args:
             jobid: The beaker jobid
-            junit: The directory where the junit XML will be written
+            fname: The junit XML filename will be written
         """
         args = ["bkr", "job-results", "--format=junit-xml"]
         args.append(jobid)
 
-        fname = "%s/%s.xml" % (junit, jobid.replace(":", "_").lower())
         with open(fname, 'w') as fileh:
             bkr = subprocess.Popen(args, stdout=fileh)
             bkr.communicate()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -13,7 +13,6 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """Test cases for runner module."""
 import os
-import tempfile
 import unittest
 
 import xml.etree.ElementTree as etree
@@ -87,24 +86,6 @@ class TestRunner(unittest.TestCase):
         mock_popen.return_value.communicate.return_value = (test_xml, '')
         result = self.myrunner.getresultstree(jobid=0)
         self.assertEqual(next(x.text for x in result.iter('test')), 'TEST')
-
-    @mock.patch('subprocess.Popen')
-    def test_dumpjunitresults(self, mock_popen):
-        """Ensure dumpjunitresults() works."""
-        mock_popen.return_value.returncode = 0
-        mock_popen.return_value.communicate.return_value = (
-            'stdout',
-            'stderr'
-        )
-
-        junit_dir = tempfile.mkdtemp()
-        self.myrunner.dumpjunitresults("J:00001", junit_dir)
-        expected_file = "{}/j_00001.xml".format(junit_dir)
-        self.assertTrue(os.path.exists(expected_file))
-
-        # Clean up
-        os.unlink(expected_file)
-        os.rmdir(junit_dir)
 
     def test_forget_cid_withj(self):
         """Ensure __forget_cid() works with jobs."""


### PR DESCRIPTION
I make PR for `BeakerRunner.dumpjunitresult()` accepting the output file name
Fixes #273