### PR TITLE
Add sftp support for publish 

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -382,7 +382,7 @@ def cmd_publish(cfg):
     """
     Publish (copy) the kernel tarball and configuration to the specified
     location, generating their resulting URLs, using the specified "publisher".
-    Only "cp" and "scp" pusblishers are supported at the moment.
+    Only "cp", "scp" and "sftp" pusblishers are supported at the moment.
 
     Args:
         cfg:    A dictionary of skt configuration.

--- a/skt/publisher.py
+++ b/skt/publisher.py
@@ -90,6 +90,27 @@ class ScpPublisher(Publisher):
         return self.geturl(source)
 
 
+class SftpPublisher(Publisher):
+    TYPE = 'sftp'
+
+    def publish(self, source):
+        """
+        Copy the source file to public destination.
+
+        Args:
+            source: Source file path.
+
+        Returns:
+            Published URL corresponding to the specified source.
+        """
+        sp = subprocess.Popen(['sftp', self.destination],
+                              shell=False, stdin=subprocess.PIPE)
+        sp.stdin.write("put -r %s\n" % source)
+        sp.stdin.close()
+        sp.wait()
+        return self.geturl(source)
+
+
 def getpublisher(ptype, parg, pburl):
     """
     Create an instance of a "publisher" subclass with specified arguments.


### PR DESCRIPTION
I make PR to add sftp support for `publish` to transfer the kernel tarball, configuration, and build information to the specified location. I also add docstring. 