### PR TITLE
Don't abort if no logs are found

### DIFF
--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -525,7 +525,11 @@ class Reporter(object):
                     ltp_results = runner.get_ltp_lite_logs(jobid)
                     for ltp_recipe, ltp_logs in ltp_results.items():
                         result += ['\n  ' + ltp_recipe]
-                        result += ['    ' + ltp_log for ltp_log in ltp_logs]
+                        if not any(ltp_logs):
+                            result += ['    N/A']
+                            continue
+                        result += ['    ' + ltp_log
+                                   for ltp_log in ltp_logs if ltp_log]
 
                 if slshwurl is not None:
                     if system not in minfo["short"]:


### PR DESCRIPTION
If the job aborts with kernel panic before LTP completes, there won't be
any LTP logs present. The situation resulted in exception when trying to
report the results and not sending out kernel panics. Instead, let's try
to format the log URLs only if there are any present and fix this bug.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>