### PR TITLE
Always publish kernel config

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -388,19 +388,16 @@ def cmd_publish(cfg):
     """
     publisher = skt.publisher.getpublisher(*cfg.get('publisher'))
 
+    if cfg.get('buildconf'):
+        cfgurl = publisher.publish(cfg.get('buildconf'))
+        save_state(cfg, {'cfgurl': cfgurl})
+
     if not cfg.get('tarpkg'):
         raise Exception("skt publish is missing \"--tarpkg <path>\" option")
 
-    cfgurl = None
-
     url = publisher.publish(cfg.get('tarpkg'))
     logging.info("published url: %s", url)
-
-    if cfg.get('buildconf'):
-        cfgurl = publisher.publish(cfg.get('buildconf'))
-
-    save_state(cfg, {'buildurl': url,
-                     'cfgurl': cfgurl})
+    save_state(cfg, {'buildurl': url})
 
 
 @junit


### PR DESCRIPTION
Publish kernel config before checking if tarball is present. The
reporter needs to get to the config even if the build failed.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>