### PR TITLE
Return SKT_ERROR if max count of aborted jobs is reached

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -326,6 +326,7 @@ class BeakerRunner(Runner):
             if self.aborted_count == MAX_ABORTED:
                 logging.error('Max count of aborted jobs achieved, please '
                               'check your infrastructure!')
+                return SKT_ERROR
 
             for (recipe, data) in self.failures.iteritems():
                 # Treat single failure as a fluke during normal run


### PR DESCRIPTION
Might be a more useful indicator of what's going on than SKT_SUCCESS.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>