### PR TITLE
Implement a blacklist for Beaker machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,10 +331,19 @@ template. If you remove the `--wait` option, the command will return once the
 job was submitted. Otherwise it will wait for its completion and report the
 result.
 
-E.g. to run the tests from a job XML template named `beakerjob.xml`, execute:
+In case running on specific hosts is not desired, one can use a simple text
+file containing one hostname per line, and pass the file via `blacklist`
+parameter. Tests will not attempt to run on machines which names are specified
+in the file. This is useful for example as a temporary fix in case the hardware
+is buggy and the maintainer of the pool doesn't have time to exclude it from
+the pool.
+
+E.g. to run the tests from a job XML template named `beakerjob.xml` and exclude
+machines in `blacklist.txt` file execute:
 
     skt --rc skt-rc --state --workdir skt-workdir -vv run \
-        --runner beaker '{"jobtemplate": "beakerjob.xml"}' \
+        --runner beaker '{"jobtemplate": "beakerjob.xml", \
+	                  "blacklist": "blacklist.txt"}, \
         --wait
 
 ### Report

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -958,6 +958,13 @@ def load_config(args):
         except OSError:
             pass
 
+    # Get absolute path to blacklist file
+    if cfg.get('runner') and cfg['runner'][0] == 'beaker' and \
+            'blacklist' in cfg['runner'][1]:
+        cfg['runner'][1]['blacklist'] = full_path(
+            cfg['runner'][1]['blacklist']
+        )
+
     # Preparation for output directory option
     if os.access(cfg.get('workdir'), os.W_OK | os.X_OK):
         cfg['output_dir'] = cfg.get('workdir')


### PR DESCRIPTION
Sometimes, running on a specific machine is not desired. This patch
allows to list hostnames of those machines in a text file, which are
then included in the submitted Beaker XML, ensuring the tests are not
ran on these machines.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>