### PR TITLE
Don't treat panics as failed installation

### DIFF
--- a/skt/runner.py
+++ b/skt/runner.py
@@ -472,7 +472,9 @@ class BeakerRunner(Runner):
                             ".//task[@name='/distribution/kpkginstall']"
                         )
                         if tinst is not None and \
-                                tinst.attrib.get("result") != "Pass":
+                                tinst.attrib.get("result") not in [
+                                    'Pass', 'Panic'
+                                ]:
                             logging.warning("%s failed before kernelinstall, "
                                             "resubmitting", cid)
                             self.__forget_cid(cid)


### PR DESCRIPTION
If the new kernel is successfully installed, the machine tries to boot
it. It sometimes happens that a kernel panic is encountered during the
boot, which is still part of the kpkginstall task. Detect this as a
kernel problem, not infrastructure error.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>