### PR TITLE
Publisher.py: Add docstring, and fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The following commands are supported by `skt`:
 * `publish`
     - Publish (copy) the kernel tarball, configuration, and build information
       to the specified location, generating their resulting URLs, using the
-      specified "publisher". Only "cp" and "scp" pusblishers are supported at
+      specified "publisher". Only "cp" and "scp" publishers are supported at
       the moment. This command expects `build` command to have completed
       succesfully.
 * `run`

--- a/skt/publisher.py
+++ b/skt/publisher.py
@@ -60,6 +60,15 @@ class CpPublisher(Publisher):
     TYPE = 'cp'
 
     def publish(self, source):
+        """
+        Copy the source file to public destination.
+
+        Args:
+            source: Source file path.
+
+        Returns:
+            Published URL corresponding to the specified source.
+        """
         shutil.copy(source, self.destination)
         return self.geturl(source)
 
@@ -68,6 +77,15 @@ class ScpPublisher(Publisher):
     TYPE = 'scp'
 
     def publish(self, source):
+        """
+        Copy the source file to public destination.
+
+        Args:
+            source: Source file path.
+
+        Returns:
+            Published URL corresponding to the specified source.
+        """
         subprocess.check_call(["scp", source, self.destination])
         return self.geturl(source)
 


### PR DESCRIPTION
I make PR to add docstring in `publisher.py` and fix typo in `README`