### PR TITLE
Don't raise exception if can't publish tarball

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -393,12 +393,12 @@ def cmd_publish(cfg):
         cfgurl = publisher.publish(cfg.get('buildconf'))
         save_state(cfg, {'cfgurl': cfgurl})
 
-    if not cfg.get('tarpkg'):
-        raise Exception("skt publish is missing \"--tarpkg <path>\" option")
-
-    url = publisher.publish(cfg.get('tarpkg'))
-    logging.info("published url: %s", url)
-    save_state(cfg, {'buildurl': url})
+    if cfg.get('tarpkg'):
+        url = publisher.publish(cfg.get('tarpkg'))
+        logging.info("published tarpkg url: %s", url)
+        save_state(cfg, {'buildurl': url})
+    else:
+        logging.debug('No kernel tarball to publish found!')
 
 
 @junit


### PR DESCRIPTION
Allow publisher to be ran anytime, even if the build fails. It makes it
easier to publish what is available instead of raising an exception,
especially since the build command returns non-zero code if it failed so
the caller knows whether the build succeeded or not.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>