### PR TITLE
Kerneltree.py: Remove unused cleanup() method

### DIFF
--- a/skt/kerneltree.py
+++ b/skt/kerneltree.py
@@ -15,7 +15,6 @@
 import logging
 import os
 import re
-import shutil
 import subprocess
 
 from skt.misc import join_with_slash, get_patch_mbox, SKT_SUCCESS, SKT_FAIL
@@ -238,10 +237,6 @@ class KernelTree(object):
         head = self.get_commit_hash()
         logging.info("baserepo %s: %s", self.ref, head)
         return str(head).rstrip()
-
-    def cleanup(self):
-        logging.info("cleaning up %s", self.wdir)
-        shutil.rmtree(self.wdir)
 
     def __get_remote_url(self, remote):
         rurl = None

--- a/tests/test_kerneltree.py
+++ b/tests/test_kerneltree.py
@@ -76,11 +76,6 @@ class KernelTreeTest(unittest.TestCase):
         if os.path.isdir(self.tmpdir):
             shutil.rmtree(self.tmpdir)
 
-    def test_cleanup(self):
-        """Ensure cleanup() removes the workdir."""
-        ktree = self.kerneltree
-        ktree.cleanup()
-
     def test_checkout(self):
         """Ensure checkout() runs git commands to check out a ref."""
         self.m_popen_good.communicate = Mock(return_value=('stdout', None))


### PR DESCRIPTION
I make PR to remove unused `cleanup()` method. One more thing is when the command `merge` is fail, it left the empty `wdir` (skt-workdir in example).  This method probably is kept for handling this issue if you want to remove the empty `wdir`