### PR TITLE
Fix merge-ref command line option parsing

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -918,6 +918,9 @@ def load_config(args):
 
     if not cfg.get('merge_ref'):
         cfg['merge_ref'] = []
+    else:
+        for index, to_merge in enumerate(cfg['merge_ref']):
+            cfg['merge_ref'][index] = to_merge.split()
 
     for section in config.sections():
         if section.startswith("merge-"):

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -127,10 +127,12 @@ class TestExecutable(unittest.TestCase):
             '[config]',
             'foo=bar',
             'workdir=/tmp/workdir',
-            'merge_ref=master',
             'basecfg=.config',
             'buildconf=value',
             'tarpkg=value',
+            '[merge-1]',
+            'url = repourl',
+            'ref = master'
         ]
         args = ['--rc', '/tmp/testing.ini', '--workdir', '/tmp/workdir',
                 '--state', '--junit', '/tmp/junit', 'report', '--reporter',


### PR DESCRIPTION
While the config option is correctly parsed into a list of [url, ref]
sublists, the command line one is not and stays as a list of strings.
This gets wrongly expanded when calling the merge_git_ref() method.

Fix the option parsing and the related test.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>