### PR TITLE
Remove stderr keyword arg from git call

### DIFF
--- a/skt/kerneltree.py
+++ b/skt/kerneltree.py
@@ -273,8 +273,7 @@ class KernelTree(object):
         head = None
 
         try:
-            self.__git_cmd("remote", "add", remote_name, uri,
-                           stderr=subprocess.PIPE)
+            self.__git_cmd("remote", "add", remote_name, uri)
         except subprocess.CalledProcessError:
             pass
 


### PR DESCRIPTION
stderr is already specified in __git_cmd_call. Specifying it again
results in TypeError (multiple values for keyword argument stderr).

Fixes #318

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>