### PR TITLE
Add support output directory for result

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,18 +131,18 @@ written to the `<JUNIT_DIR>` directory.
 
 To checkout a kernel tree run:
 
-    skt --rc <SKTRC> --state --workdir <WORKDIR> -vv \
+    skt --rc <SKTRC> --state --workdir <WORKDIR> --output-dir <OUTDIR> -vv \
         merge --baserepo <REPO_URL> --ref <REPO_REF>
 
 Here `<SKTRC>` would be the configuration file to retrieve the configuration
 and the state from, and store the updated state in. `<WORKDIR>` would be the
-directory to clone and checkout the kernel repo to, `<REPO_URL>` would be the
-source kernel Git repo URL, and `<REPO_REF>` would be the reference to
-checkout.
+directory to clone and checkout the kernel repo to, `<OUTDIR>` would be
+directory to store output files, `<REPO_URL>` would be the source
+kernel Git repo URL, and `<REPO_REF>` would be the reference to checkout.
 
 E.g. to checkout "master" branch of the "net-next" repo:
 
-    skt --rc skt-rc --state --workdir skt-workdir -vv \
+    skt --rc skt-rc --state --workdir skt-workdir --output-dir skt-outdir -vv \
         merge --baserepo git://git.kernel.org/pub/scm/linux/kernel/git/davem/net-next.git \
               --ref master
 

--- a/skt/executable.py
+++ b/skt/executable.py
@@ -558,6 +558,12 @@ def setup_parser():
         help="Path to work dir"
     )
     parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=str,
+        help="Path to output directory"
+    )
+    parser.add_argument(
         "-w",
         "--wipe",
         help=(
@@ -969,8 +975,14 @@ def load_config(args):
             cfg['runner'][1]['blacklist']
         )
 
-    # Preparation for output directory option
-    if os.access(cfg.get('workdir'), os.W_OK | os.X_OK):
+    # Create and get an absolute path for the output directory
+    if cfg.get('output_dir'):
+        cfg['output_dir'] = full_path(cfg.get('output_dir'))
+        try:
+            os.mkdir(cfg.get('output_dir'))
+        except OSError:
+            pass
+    elif os.access(cfg.get('workdir'), os.W_OK | os.X_OK):
         cfg['output_dir'] = cfg.get('workdir')
     else:
         cfg['output_dir'] = os.getcwd()


### PR DESCRIPTION
I make PR to add support output directory for result. If the command has `--output_dir` or `-o` option, it is going to create the output directory to store result. And the default is working directory. 