### PR TITLE
Executable.py: Add removing output directory in cmd_cleanup()

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -492,8 +492,11 @@ def cmd_cleanup(cfg):
         except OSError:
             pass
 
-    if cfg.get('wipe') and cfg.get('workdir'):
-        shutil.rmtree(cfg.get('workdir'))
+    if cfg.get('wipe'):
+        if cfg.get('workdir'):
+            shutil.rmtree(cfg.get('workdir'))
+        if cfg.get('output_dir'):
+            shutil.rmtree(cfg.get('output_dir'))
 
 
 def cmd_all(cfg):


### PR DESCRIPTION
I make PR to remove the whole output directory, if the global `--wipe` option was specified.