### PR TITLE
Use defusedxml for XML parsing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ include_package_data = True
 install_requires = flake8
                    junit_xml
                    mock
+                   defusedxml
                    responses
                    pycodestyle!=2.4.0
                    pylint

--- a/skt/runner.py
+++ b/skt/runner.py
@@ -20,6 +20,7 @@ import subprocess
 import time
 import xml.etree.ElementTree as etree
 
+from defusedxml.ElementTree import fromstring
 import requests
 
 from skt.misc import SKT_SUCCESS, SKT_FAIL, SKT_ERROR
@@ -133,7 +134,7 @@ class BeakerRunner(Runner):
 
         bkr = subprocess.Popen(args, stdout=subprocess.PIPE)
         (stdout, _) = bkr.communicate()
-        return etree.fromstring(stdout)
+        return fromstring(stdout)
 
     def __forget_taskspec(self, taskspec):
         """
@@ -427,7 +428,7 @@ class BeakerRunner(Runner):
         self.max_aborted = max_aborted
 
         try:
-            job_xml_tree = etree.fromstring(self.__getxml(
+            job_xml_tree = fromstring(self.__getxml(
                 {'KVER': release,
                  'KPKG_URL': url,
                  'ARCH': arch}

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -18,7 +18,7 @@ import shutil
 import tempfile
 import unittest
 
-import xml.etree.ElementTree as etree
+from defusedxml.ElementTree import fromstring
 
 import mock
 import responses
@@ -110,10 +110,10 @@ class TestStdioReporter(unittest.TestCase):
             fileh.write('Config file text from a file')
 
         # Load our sample Beaker XML files
-        self.beaker_pass_results = etree.fromstring(
+        self.beaker_pass_results = fromstring(
             read_asset("beaker_recipe_set_results.xml")
         )
-        self.beaker_fail_results = etree.fromstring(
+        self.beaker_fail_results = fromstring(
             read_asset("beaker_recipe_set_fail_results.xml")
         )
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -15,7 +15,7 @@
 import os
 import unittest
 
-import xml.etree.ElementTree as etree
+from defusedxml.ElementTree import fromstring
 import mock
 
 from skt import runner
@@ -121,7 +121,7 @@ class TestRunner(unittest.TestCase):
         """Ensure __getresults() works."""
         # pylint: disable=W0212,E1101
         self.myrunner.job_to_recipe_set_map = {'jobid': set(['recipeset'])}
-        self.myrunner.recipe_set_results['recipeset'] = etree.fromstring(
+        self.myrunner.recipe_set_results['recipeset'] = fromstring(
             misc.get_asset_content('beaker_recipe_set_results.xml')
         )
 
@@ -142,7 +142,7 @@ class TestRunner(unittest.TestCase):
         """Ensure __getresults() handles a job failure."""
         # pylint: disable=W0212,E1101
         self.myrunner.job_to_recipe_set_map = {'jobid': set(['recipeset'])}
-        self.myrunner.recipe_set_results['recipeset'] = etree.fromstring(
+        self.myrunner.recipe_set_results['recipeset'] = fromstring(
             misc.get_asset_content('beaker_fail_results.xml')
         )
 
@@ -154,7 +154,7 @@ class TestRunner(unittest.TestCase):
         """Ensure __recipe_set_to_job() works."""
         # pylint: disable=W0212,E1101
         beaker_xml = misc.get_asset_content('beaker_recipe_set_results.xml')
-        xml_parsed = etree.fromstring(beaker_xml)
+        xml_parsed = fromstring(beaker_xml)
 
         result = self.myrunner._BeakerRunner__recipe_set_to_job(xml_parsed)
         self.assertEqual(result.tag, 'job')
@@ -185,7 +185,7 @@ class TestRunner(unittest.TestCase):
         self.myrunner.whiteboard = 'test'
 
         beaker_xml = misc.get_asset_content('beaker_pass_results.xml')
-        mock_getresultstree.return_value = etree.fromstring(beaker_xml)
+        mock_getresultstree.return_value = fromstring(beaker_xml)
         mock_jobsubmit.return_value = "J:0001"
 
         # no need to wait 60 seconds


### PR DESCRIPTION
In theory, a user can pass a maliciously crafted XML, exploiting the
server/testing side. While currently it means they would exploit their
own infrastructure, if in the future there is a publicly available
service allowing people to run eg. custom tests or pass their own
Beaker XMLs, the possibility to expoit the organization running the
service grows exponentially.

xml.ElementTree is safe against external entity expansion, DTD retrieval
and decompression bomb, but not against exponential entity expansion or
quadratic blowup entity expansion. defusedxml provides a modified
fromstring method for parsing untrusted XMLs, to prevent the exploits
original ElementTree is not protected against.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>