### PR TITLE
Don't catch exceptions when aborting patch application

### DIFF
--- a/skt/kerneltree.py
+++ b/skt/kerneltree.py
@@ -316,12 +316,9 @@ class KernelTree(object):
                                              "am", "-",
                                              cwd=self.wdir)
         if status != 0:
-            try:
-                self.__git_cmd("am", "--abort", cwd=self.wdir)
-            except subprocess.CalledProcessError as exc:
-                logging.debug("%s failed with status %d and "
-                              "following output:\n%s",
-                              exc.cmd, exc.returncode, exc.output)
+            logging.error('Patch application failed with:\n%s', output)
+
+            self.__git_cmd("am", "--abort", cwd=self.wdir)
 
             with open(self.mergelog, "w") as fileh:
                 fileh.write(output)
@@ -339,12 +336,9 @@ class KernelTree(object):
         try:
             self.__git_cmd("am", path, cwd=self.wdir)
         except subprocess.CalledProcessError as exc:
-            try:
-                self.__git_cmd("am", "--abort", cwd=self.wdir)
-            except subprocess.CalledProcessError as exc:
-                logging.debug("%s failed with status %d and "
-                              "following output:\n%s",
-                              exc.cmd, exc.returncode, exc.output)
+            logging.error('Patch application failed with:\n%s', exc.output)
+
+            self.__git_cmd("am", "--abort", cwd=self.wdir)
 
             with open(self.mergelog, "w") as fileh:
                 fileh.write(exc.output)

--- a/tests/test_kerneltree.py
+++ b/tests/test_kerneltree.py
@@ -227,7 +227,8 @@ class KernelTreeTest(unittest.TestCase):
 
         self.assertIsNone(result)
 
-    def test_merge_pw_patch_failure(self):
+    @mock.patch('logging.error')
+    def test_merge_pw_patch_failure(self, mock_logging):
         """Ensure merge_patchwork_patch() handles patch failures properly."""
         mock_get_patch_mbox = mock.patch('skt.kerneltree.get_patch_mbox')
         mock_git_cmd = mock.patch('skt.kerneltree.KernelTree.'
@@ -238,6 +239,8 @@ class KernelTreeTest(unittest.TestCase):
         with mock_get_patch_mbox, mock_git_cmd, self.popen_bad:
             with self.assertRaises(Exception):
                 self.kerneltree.merge_patchwork_patch('uri')
+
+        mock_logging.assert_called_once()
 
     def test_merge_patch_file(self):
         """Ensure merge_patch_file() tries to merge a patch."""
@@ -254,7 +257,8 @@ class KernelTreeTest(unittest.TestCase):
 
         self.assertIsNone(result)
 
-    def test_merge_patch_file_failure(self):
+    @mock.patch('logging.error')
+    def test_merge_patch_file_failure(self, mock_logging):
         """Ensure merge_patch_file() handles a patch apply failure."""
         mock_check_output = mock.patch(
             'subprocess.check_output',
@@ -268,6 +272,8 @@ class KernelTreeTest(unittest.TestCase):
         with mock_check_output:
             with self.assertRaises(Exception):
                 self.kerneltree.merge_patch_file(patch_file)
+
+        mock_logging.assert_called_once()
 
     def test_merge_patch_file_missing(self):
         """Ensure merge_patch_file() fails when a patch is missing."""


### PR DESCRIPTION
If `git am --abort` goes wrong, something is seriously wrong and we
shouldn't continue as if it wasn't. Instead of catching the exception,
let skt abort when it happens.

Doing so allows to distinguish between a merge failure and error, which
means the (possibly serious) issue won't go unnoticed. The original
patch application failure is also logged before aborting so the issue
can be reproduced.

Only continue the normal flow of reporting the patch application failure
if the cleanup went fine - we have no idea why `git am --abort` went
wrong, and it could be caused by a previously messed up repository, in
which case the application error is not caused by the patch itself, and
the problem should *not* be reported to its author.

Fixes #229

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>