### PR TITLE
Don't report skipped tests

### DIFF
--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -293,21 +293,23 @@ class Reporter(object):
                     failed_tasks.append('/distribution/kpkginstall')
                 else:
                     recipe_tests = runner.get_recipe_test_list(recipe)
-                    result += ['We ran the following tests:']
-                    for test_name in recipe_tests:
-                        task_node = recipe.find(
-                            "task[@name='{}']".format(test_name)
-                        )
-                        test_result = task_node.attrib.get('result')
-                        result += ['  - {}: {}'.format(test_name,
-                                                       test_result.upper())]
-                        if test_result != 'Pass':
-                            failed_tasks.append(test_name)
+                    if recipe_tests:
+                        result += ['We ran the following tests:']
+                        for test_name in recipe_tests:
+                            task_node = recipe.find(
+                                "task[@name='{}']".format(test_name)
+                            )
+                            test_result = task_node.attrib.get('result')
+                            result += ['  - {}: {}'.format(
+                                test_name, test_result.upper()
+                            )]
+                            if test_result != 'Pass':
+                                failed_tasks.append(test_name)
 
-                        if task_node.find('fetch') is not None:
-                            result.append('    - Test URL: {}'.format(
-                                task_node.find('fetch').attrib.get('url')
-                            ))
+                            if task_node.find('fetch') is not None:
+                                result.append('    - Test URL: {}'.format(
+                                    task_node.find('fetch').attrib.get('url')
+                                ))
 
                 if failed_tasks:
                     result += [


### PR DESCRIPTION
Some tests require a specific architecture or hardware to run on. This
is handled by a test reporting "Skip" result and exiting. Detect skipped
tests and exclude them from the list of ran tests (since they didn't
actually run) and the report, to avoid confusion.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>