### PR TITLE
Exclude logs that aren't important

### DIFF
--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -319,13 +319,21 @@ class Reporter(object):
                     )
                     result += ['- {}'.format(failed_task)]
                     for log in task_node.findall('logs/log'):
+                        if any(log_name in log.attrib.get('name') for
+                               log_name in ['harness', 'setup']):
+                            continue
+
                         result += ['  {}'.format(log.attrib.get('href'))]
-                    for subtask_log in task_node.findall(
-                            'results/result/logs/log'
-                    ):
-                        result += [
-                            '  {}'.format(subtask_log.attrib.get('href'))
-                        ]
+                    for subtask in task_node.findall('results/result'):
+                        if any(subtask_name in subtask.attrib.get('path') for
+                               subtask_name in ['install']) or \
+                                subtask.attrib.get('result') == 'Pass':
+                            continue
+
+                        for subtask_log in subtask.findall('logs/log'):
+                            result += [
+                                '  {}'.format(subtask_log.attrib.get('href'))
+                            ]
 
                 result += [
                     '',

--- a/skt/runner.py
+++ b/skt/runner.py
@@ -505,15 +505,23 @@ class BeakerRunner(Runner):
                     )
                     report_string += '- {}\n'.format(failed_task)
                     for log in task_node.findall('logs/log'):
+                        if any(log_name in log.attrib.get('name') for
+                               log_name in ['harness', 'setup']):
+                            continue
+
                         report_string += '  {}\n'.format(
                             log.attrib.get('href')
                         )
-                    for subtask_log in task_node.findall(
-                            'results/result/logs/log'
-                    ):
-                        report_string += '  {}\n'.format(
-                            subtask_log.attrib.get('href')
-                        )
+                    for subtask in task_node.findall('results/result'):
+                        if any(subtask_name in subtask.attrib.get('path') for
+                               subtask_name in ['install']) or \
+                                subtask.attrib.get('result') == 'Pass':
+                            continue
+
+                        for subtask_log in subtask.findall('logs/log'):
+                            report_string += '  {}\n'.format(
+                                subtask_log.attrib.get('href')
+                            )
                     report_string += '\n'
 
                     report_string += '\n{}\n\n'.format(


### PR DESCRIPTION
Some tasks report a lot of logs, or have a lot of subtasks. If only one
of the subtasks fails, it can be complicated to find the right log in
the bunch of randomly looking links.

Exclude harness and setup logs from the email report since they contain
no actual data about the test run, and any "install" subtask logs as
well. On top of this, only include the logs to the subtasks that
actually failed.

This reduces the amount of information in the email and makes it easier
to find the logs with the actual failure descriptions.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>