### PR TITLE
Remove a default value from Popen() call

### DIFF
--- a/skt/publisher.py
+++ b/skt/publisher.py
@@ -106,7 +106,7 @@ class SftpPublisher(Publisher):
             Published URL corresponding to the specified source.
         """
         sp = subprocess.Popen(['sftp', self.destination],
-                              shell=False, stdin=subprocess.PIPE)
+                              stdin=subprocess.PIPE)
         sp.stdin.write("put -r %s\n" % source)
         sp.stdin.close()
         sp.wait()


### PR DESCRIPTION
The shell=False option is the default value. Having it explicitely
stated in the call makes people scratch their heads - what am I missing
in the code? Where was the True value passed that we need to override it
here?

We should avoid confusing code like this.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>