### PR TITLE
Remove version constraint for pycodestyle (new release of flake8)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,14 +12,12 @@ packages = find:
 # Parse the MANIFEST.in file and include those files, too.
 include_package_data = True
 # Let pip install dependencies automatically.
-# NOTE(mhayden): pycodestyle 2.4.0 has a bug that causes flake8 to fail.
-# Remove the pycodestyle constraint once upstream is fixed.
 install_requires = flake8
                    junit_xml
                    mock
                    defusedxml
                    responses
-                   pycodestyle!=2.4.0
+                   pycodestyle
                    pylint
                    requests
                    PyYAML

--- a/skt/kernelbuilder.py
+++ b/skt/kernelbuilder.py
@@ -76,7 +76,7 @@ class KernelBuilder(object):
 
     def __glob_escape(self, pathname):
         """Escape any wildcard/glob characters in pathname."""
-        return re.sub(r"[]*?[]", "[\g<0>]", pathname)
+        return re.sub(r"[]*?[]", r"[\g<0>]", pathname)
 
     def __prepare_kernel_config(self):
         """Prepare the kernel config for the compile."""


### PR DESCRIPTION
On the last release of flake8 the dependency version for pycodestyle was bumped to >= 2.4.0 and there is no newer version for pycodestyle yet i.e. skt is not installable.