### PR TITLE
Use commit subject in email reports

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -202,9 +202,11 @@ def cmd_merge(cfg):
         fetch_depth=cfg.get('fetch_depth')
     )
     bhead = ktree.checkout()
+    bsubject = ktree.get_commit_subject(bhead)
     commitdate = ktree.get_commit_date(bhead)
     save_state(cfg, {'baserepo': cfg.get('baserepo'),
                      'basehead': bhead,
+                     'basesubject': bsubject,
                      'commitdate': commitdate})
 
     remove_oldresult(cfg.get('output_dir'), 'merge.')
@@ -296,9 +298,11 @@ def cmd_merge(cfg):
 
     kpath = ktree.getpath()
     buildhead = ktree.get_commit_hash()
+    buildsubject = ktree.get_commit_subject()
 
     save_state(cfg, {'workdir': kpath,
-                     'buildhead': buildhead})
+                     'buildhead': buildhead,
+                     'buildsubject': buildsubject})
 
     report_results(merge_result_path, 'true',
                    merge_report_path, report_string)

--- a/skt/kerneltree.py
+++ b/skt/kerneltree.py
@@ -150,6 +150,29 @@ class KernelTree(object):
             logging.debug("Adding missing remote 'origin': %s", self.uri)
             self.__git_cmd("remote", "add", "origin", self.uri)
 
+    def get_commit_details(self, ref=None, show_format="%H"):
+        """
+        Get details about a particular commit by specifying an output format.
+        Args:
+            ref: An optional reference to a commit in a git repo to be
+                 inspected. The current commit is used if a ref is not
+                 provided.
+            show_format: A `git show` format string to use to gather details.
+        Returns:
+            The stdout from `git show`.
+        """
+        args = ["show",
+                "--format={}".format(show_format),
+                "-s"]
+
+        # If a ref was specified, append it to the end of the git command.
+        if ref is not None:
+            args.append(ref)
+
+        stdout = self.__git_cmd(*args)
+
+        return stdout.rstrip()
+
     def get_commit_date(self, ref=None):
         """
         Get the committer date of the commit pointed at by the specified

--- a/skt/kerneltree.py
+++ b/skt/kerneltree.py
@@ -198,6 +198,18 @@ class KernelTree(object):
         """
         return self.get_commit_details(ref, show_format='%H')
 
+    def get_commit_subject(self, ref=None):
+        """
+        Get the subject line of a commit specified by an optional ref.
+        Args:
+            ref: An optional reference to a commit in a git repo to be
+                 inspected. The current commit is used if a ref is not
+                 provided.
+        Returns:
+            The commit's subject line.
+        """
+        return self.get_commit_details(ref, show_format='%s')
+
     def checkout(self):
         """
         Clone and checkout the specified reference from the specified repo URL

--- a/skt/kerneltree.py
+++ b/skt/kerneltree.py
@@ -175,58 +175,28 @@ class KernelTree(object):
 
     def get_commit_date(self, ref=None):
         """
-        Get the committer date of the commit pointed at by the specified
-        reference, or of the currently checked-out commit, if not specified.
-
+        Get the commit date of the commit specified by an optional ref.
         Args:
-            ref:    The reference to commit to get the committer date of,
-                    or None, if the currently checked-out commit should be
-                    used instead.
+            ref: An optional reference to a commit in a git repo to be
+                 inspected. The current commit is used if a ref is not
+                 provided.
         Returns:
             The epoch timestamp string of the commit's committer date.
         """
-        args = ["git",
-                "--work-tree", self.wdir,
-                "--git-dir", self.gdir,
-                "show",
-                "--format=%ct",
-                "-s"]
-
-        if ref is not None:
-            args.append(ref)
-
-        logging.debug("git_commit_date: %s", args)
-        grs = subprocess.Popen(args, stdout=subprocess.PIPE)
-        (stdout, _) = grs.communicate()
-
-        return int(stdout.rstrip())
+        result = self.get_commit_details(ref, show_format='%ct')
+        return int(result)
 
     def get_commit_hash(self, ref=None):
         """
-        Get the full hash of the commit pointed at by the specified reference,
-        or of the currently checked-out commit, if not specified.
-
+        Get the full hash of a commit specified by an optional ref.
         Args:
-            ref:    The reference to commit to get the hash of, or None, if
-                    the currently checked-out commit should be used instead.
+            ref: An optional reference to a commit in a git repo to be
+                 inspected. The current commit is used if a ref is not
+                 provided.
         Returns:
             The commit's full hash string.
         """
-        args = ["git",
-                "--work-tree", self.wdir,
-                "--git-dir", self.gdir,
-                "show",
-                "--format=%H",
-                "-s"]
-
-        if ref is not None:
-            args.append(ref)
-
-        logging.debug("git_commit: %s", args)
-        grs = subprocess.Popen(args, stdout=subprocess.PIPE)
-        (stdout, _) = grs.communicate()
-
-        return stdout.rstrip()
+        return self.get_commit_details(ref, show_format='%H')
 
     def checkout(self):
         """

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -138,8 +138,11 @@ class Reporter(object):
         self.multi_job_ids = []
 
     def __stateconfigdata(self, mergedata):
-        mergedata['base'] = (self.cfg.get("baserepo"),
-                             self.cfg.get("basehead"))
+        # Store the repo URL, base commit SHA, and subject for that commit.
+        mergedata['baserepo'] = self.cfg.get("baserepo")
+        mergedata['basehead'] = self.cfg.get("basehead")
+        mergedata['basesubject'] = self.cfg.get('basesubject')
+
         if self.cfg.get("mergerepos"):
             mrl = self.cfg.get("mergerepos")
             mhl = self.cfg.get("mergeheads")

--- a/skt/templates/merge_details.j2
+++ b/skt/templates/merge_details.j2
@@ -1,8 +1,8 @@
 
 We cloned this repository and checked out a ref:
 
-  Repo: {{ mergedata['base'][0] }}
-  Ref:  {{ mergedata['base'][1] }}
+  Repo: {{ mergedata['baserepo'] }}
+  Ref:  {{ mergedata['basehead'][:12] }} {{ mergedata['basesubject'] }}
 
 We then merged the following {{ patch_plural }} with `git am`:
 

--- a/skt/templates/report.j2
+++ b/skt/templates/report.j2
@@ -6,12 +6,16 @@ Hello,
 {% if mergedata['localpatch'] or mergedata['patchwork'] %}
 {# We tested patches against a kernel tree. #}
 We ran automated tests on a patchset that was proposed for merging into this
-kernel tree. The results of these automated tests are provided below.
+kernel tree. The patches were applied to:
 {% else %}
 {# We ran baseline tests against a kernel tree. #}
-We ran automated tests on a recent commit from this kernel tree. The results
-of these automated tests are provided below.
+We ran automated tests on a recent commit from this kernel tree:
 {% endif %}
+
+       Kernel repo: {{ mergedata['baserepo'] }}
+            Commit: {{ mergedata['basehead'][:12] }} {{ mergedata['basesubject']}}
+
+The results of these automated tests are provided below.
 
 {# What is the overall job result? #}
 {% if multireport_failed.name == 'TEST' %}
@@ -32,9 +36,6 @@ of these automated tests are provided below.
            Compile: OK
      Hardware test: OK
 {% endif %}
-
-       Kernel repo: {{ mergedata['base'][0] }}
-            Commit: {{ mergedata['base'][1] }}
 
 {% if multireport_failed.name != 'PASS' %}
     {% if multireport_failed.name == 'MERGE' %}


### PR DESCRIPTION
This PR:

* consolidates the `git show` methods into a common method
* adds a new method to retrieve the subject line of the current commit
* updates reports to mention the git repo/commit/subject first
* adds the commit subject to the reports