### PR TITLE
Add kernel repo name to subject line

### DIFF
--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -412,6 +412,18 @@ class Reporter(object):
         )
         return result
 
+    def _get_repo_name(self, baserepo):
+        """
+        Generate a short repository name based on the contents of 'baserepo'.
+
+        Args:
+            baserepo: A URL to a git repository.
+
+        Returns: A string containing the repository name.
+        """
+        repo_name = os.path.basename(baserepo)
+        return os.path.splitext(repo_name)[0]
+
     def _get_multisubject(self):
         """
         Generate a subject line for the report based on test results.
@@ -419,7 +431,7 @@ class Reporter(object):
         Returns: A string.
         """
         status = 'PASS'
-        detail = 'Report'
+        detail = 'Test report'
         krelease = ''
 
         if self.multireport_failed != MultiReportFailure.PASS:
@@ -432,7 +444,11 @@ class Reporter(object):
 
         # Kernel release should be same for all kernels built
         if self.cfg.get("krelease"):
-            krelease = " for kernel %s" % self.cfg.get("krelease")
+            repo_name = self._get_repo_name(self.cfg.get('baserepo'))
+            krelease = " for kernel {} ({})".format(
+                self.cfg.get("krelease"),
+                repo_name
+            )
 
         return "{}: {}{}".format(status, detail, krelease)
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -291,7 +291,7 @@ class TestStdioReporter(unittest.TestCase):
         report = testprint.getvalue().strip()
 
         required_strings = [
-            'Subject: FAIL: Report for kernel 3.10.0',
+            'Subject: FAIL: Test report for kernel 3.10.0 (kernel)',
             'Overall result: FAILED',
             'Hardware test: FAILED',
             self.basecfg['basehead'],
@@ -333,7 +333,7 @@ class TestStdioReporter(unittest.TestCase):
         report = testprint.getvalue().strip()
 
         required_strings = [
-            'Subject: PASS: Report for kernel 3.10.0',
+            'Subject: PASS: Test report for kernel 3.10.0 (kernel)',
             'Overall result: PASSED',
             self.basecfg['basehead'],
             self.basecfg['baserepo'],
@@ -369,7 +369,7 @@ class TestStdioReporter(unittest.TestCase):
         report = testprint.getvalue().strip()
 
         required_strings = [
-            'Subject: PASS: Report for kernel 3.10.0',
+            'Subject: PASS: Test report for kernel 3.10.0 (kernel)',
             'Overall result: PASSED',
             self.basecfg['basehead'],
             self.basecfg['baserepo'],
@@ -412,7 +412,7 @@ class TestStdioReporter(unittest.TestCase):
         report = testprint.getvalue().strip()
 
         required_strings = [
-            'Subject: PASS: Report',
+            'Subject: PASS: Test report',
             self.basecfg['basehead'],
             self.basecfg['baserepo'],
         ]
@@ -442,7 +442,7 @@ class TestStdioReporter(unittest.TestCase):
         report = testprint.getvalue().strip()
 
         required_strings = [
-            'Subject: PASS: Report for kernel 3.10.0',
+            'Subject: PASS: Test report for kernel 3.10.0 (kernel)',
             'Overall result: PASS',
             self.basecfg['basehead'],
             self.basecfg['baserepo'],
@@ -493,7 +493,7 @@ class TestStdioReporter(unittest.TestCase):
         report = testprint.getvalue().strip()
 
         required_strings = [
-            'PASS: Report for kernel 3.10.0',
+            'PASS: Test report for kernel 3.10.0 (kernel)',
             'Overall result: PASSED',
             self.basecfg['basehead'],
             self.basecfg['baserepo'],
@@ -544,7 +544,7 @@ class TestStdioReporter(unittest.TestCase):
         report = testprint.getvalue().strip()
 
         required_strings = [
-            'FAIL: Report for kernel 3.10.0',
+            'FAIL: Test report for kernel 3.10.0 (kernel)',
             'Overall result: FAILED',
             'Hardware test: FAILED',
             self.basecfg['basehead'],
@@ -602,7 +602,7 @@ class TestStdioReporter(unittest.TestCase):
         report = testprint.getvalue().strip()
 
         required_strings = [
-            'FAIL: Report for kernel 3.10.0',
+            'FAIL: Test report for kernel 3.10.0 (kernel)',
             'Overall result: FAILED',
             'Hardware test: FAILED',
             self.basecfg['basehead'],


### PR DESCRIPTION
Make test emails easier to read by including the kernel repo name
in the subject line. Update tests to check for the new string.

Signed-off-by: Major Hayden <major@redhat.com>
