### PR TITLE
Ensure jinja2 templates are installed w/pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.md
 include LICENSE
 include skt/*
+include skt/templates/*
 include tests/*


### PR DESCRIPTION
The templates directory must be mentioned specifically in `MANIFEST.in`
to ensure that pip installs the jinja2 templates properly.

Signed-off-by: Major Hayden <major@redhat.com>