### PR TITLE
Test reporting in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,12 @@ defaults: &defaults
             skt -vv --state -d workdir --rc sktrc build -c config \
                 --cfgtype tinyconfig
         working_directory: /tmp/skt_test
+    - run:
+        name: Test `skt report`
+        command: |
+            skt -vv --state -d workdir --rc sktrc report \
+                --reporter stdio
+        working_directory: /tmp/skt_test
     - store_artifacts:
         path: /tmp/skt_test/workdir/*.log
     - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ defaults: &defaults
     - checkout
     - run:
         name: Install skt using pip
-        command: pip install .
+        command: pip install --user .
     - run:
         name: Prepare git
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ defaults: &defaults
           skt -vv --state -d workdir --rc sktrc merge \
             --pw https://patchwork.ozlabs.org/patch/895383/ \
             -b git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git \
-            --ref v4.16 \
+            --ref v4.19 \
             --fetch-depth 1
         working_directory: /tmp/skt_test
     - run:


### PR DESCRIPTION
We can do more functional testing in CircleCI and reporting is a good place to start. This PR enables stdio reporting testing and changes the container images to the new fmk containers.