### PR TITLE
Set minumum Jinja2 version to 2.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ packages = find:
 include_package_data = True
 # Let pip install dependencies automatically.
 install_requires = flake8
-                   jinja2
+                   jinja2>=2.10
                    junit_xml
                    mock
                    defusedxml


### PR DESCRIPTION
Render templates consistently by setting a minimum version of Jinja2.

Signed-off-by: Major Hayden <major@redhat.com>