### PR TITLE
Don't add 'csv' to config filename

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -362,7 +362,7 @@ def cmd_build(cfg):
         logging.info("tarball path: %s", ttgz)
         save_state(cfg, {'tarpkg': ttgz})
 
-    tconfig = '%s.csv.config' % cfg.get('buildhead')
+    tconfig = '%s.config' % cfg.get('buildhead')
     shutil.copyfile(builder.get_cfgpath(), tconfig)
 
     krelease = builder.getrelease()


### PR DESCRIPTION
The kernel config filename is being copied with a 'csv' in the filename
and that is not needed.

Signed-off-by: Major Hayden <major@redhat.com>