### PR TITLE
reporter: Support Cc and Bcc in MailReporter

### DIFF
--- a/skt/executable.py
+++ b/skt/executable.py
@@ -784,6 +784,18 @@ def setup_parser():
         help="Report recipient's email address"
     )
     parser_report.add_argument(
+        "--mail-cc",
+        action='append',
+        type=str,
+        help="Report copy recipient's email address"
+    )
+    parser_report.add_argument(
+        "--mail-bcc",
+        action='append',
+        type=str,
+        help="Report hidden copy recipient's email address"
+    )
+    parser_report.add_argument(
         "--mail-from",
         type=str,
         help="Report sender's email address"
@@ -970,6 +982,8 @@ def load_config(args):
         cfg['reporter'] = {
             'type': cfg.get('type'),
             'mail_to': cfg.get('mail_to'),
+            'mail_cc': cfg.get('mail_cc'),
+            'mail_bcc': cfg.get('mail_bcc'),
             'mail_from': cfg.get('mail_from'),
             'mail_subject': cfg.get('mail_subject'),
             'mail_header': cfg.get('mail_header')

--- a/skt/reporter.py
+++ b/skt/reporter.py
@@ -498,6 +498,8 @@ class MailReporter(Reporter):
         # Get all of the required fields to send an email
         self.mailfrom = cfg['reporter']['mail_from']
         self.mailto = [to.strip() for to in cfg['reporter']['mail_to']]
+        self.mailcc = [cc.strip() for cc in cfg['reporter']['mail_cc']]
+        self.mailbcc = [bcc.strip() for bcc in cfg['reporter']['mail_bcc']]
         self.headers = [headers.strip() for headers in
                         cfg['reporter']['mail_header']]
         self.subject = cfg['reporter']['mail_subject']
@@ -513,6 +515,7 @@ class MailReporter(Reporter):
         if self.subject:
             msg['Subject'] = self.subject
         msg['To'] = ', '.join(self.mailto)
+        msg['Cc'] = ', '.join(self.mailcc)
         msg['From'] = self.mailfrom
 
         # Add any extra headers
@@ -542,5 +545,7 @@ class MailReporter(Reporter):
             msg.attach(tmp)
 
         mailserver = smtplib.SMTP(self.smtp_url)
-        mailserver.sendmail(self.mailfrom, self.mailto, msg.as_string())
+        mailserver.sendmail(self.mailfrom,
+                            self.mailto + self.mailcc + self.mailbcc,
+                            msg.as_string())
         mailserver.quit()


### PR DESCRIPTION
Add support for specifying Cc and Bcc addresses to the MailReporter and
support for corresponding options to the command line.

This is needed to be able to get copy of reports we send upstream on our
internal maillists without exposing them.