### PR TITLE
drop ##VAR## substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,24 +95,15 @@ quieter, shorter output.
 
 To run the tests you will need access to a
 [Beaker](https://beaker-project.org/) instance configured to the point where
-`bkr whoami` completes successfully. You will also need a template file for
-generating a Beaker job XML, which runs the tests. The template file can
-contain the following placeholder strings replaced by `skt` before submitting
-the job XML to Beaker:
-
-* `##KVER##`
-    - The kernel release version output by `make -s kernelrelease`.
-* `##KPKG_URL##`
-    - The URL of the kernel tarball, generated and published to with
-      `publish`.
-
-Below is an example of a superficial template. Note that it won't work as is.
+`bkr whoami` completes successfully. You will also need Beaker job XML file,
+ which runs the tests. 
+Below is an example of this file. Note that it won't work as is.
 
 ```XML
 <job>
-  <whiteboard>skt ##KVER##</whiteboard>
+  <whiteboard>skt kernel-version</whiteboard>
   <recipeSet>
-    <recipe whiteboard="##KVER##">
+    <recipe whiteboard="kernel-version">
       <distroRequires>
         <and>
           <distro_family op="=" value="Fedora26"/>
@@ -132,8 +123,8 @@ Below is an example of a superficial template. Note that it won't work as is.
       <task name="/distribution/install" role="STANDALONE"/>
       <task name="/distribution/kpkginstall" role="STANDALONE">
         <params>
-          <param name="KPKG_URL" value="##KPKG_URL##"/>
-          <param name="KVER" value="##KVER##"/>
+          <param name="KPKG_URL" value="http://url_to_kernel"/>
+          <param name="KVER" value="kernel-version"/>
         </params>
       </task>
     </recipe>
@@ -141,7 +132,7 @@ Below is an example of a superficial template. Note that it won't work as is.
 </job>
 ```
 
-Provided you have both Beaker access and a suitable job XML template, you can
+Provided you have both Beaker access and a suitable job XML file, you can
 run the tests with the built kernel as such:
 
     skt --rc <SKTRC> --state --workdir <WORKDIR> -vv run --wait
@@ -154,7 +145,7 @@ jobowner=username
 blacklist=beaker-blacklist.txt
 
 Here, `<jobtemplate>` is the name of the file with the Beaker job XML
-template. If you remove the `--wait` option, the command will return once the
+file. If you remove the `--wait` option, the command will return once the
 job was submitted. Otherwise it will wait for its completion and report the
 result.
 

--- a/skt/runner.py
+++ b/skt/runner.py
@@ -29,7 +29,6 @@ from defusedxml.ElementTree import ParseError
 
 from skt.misc import SKT_SUCCESS, SKT_FAIL, SKT_ERROR, SKT_BOOT
 from skt.misc import is_task_waived
-from cki_lib.glue import do_xml_replacements
 from cki_lib.misc import safe_popen, retry_safe_popen
 
 
@@ -269,7 +268,7 @@ class BeakerRunner:
             return SKT_BOOT, f'recipeid {recipe_id} hit EWD in boottest!'
 
         if self.has_aborted:
-            return SKT_ERROR, f'too many aborted recipes!'
+            return SKT_ERROR, 'too many aborted recipes!'
 
         prev_task = None
         for task in recipe_result.findall('task'):
@@ -700,11 +699,8 @@ class BeakerRunner:
         self.max_aborted = max_aborted
 
         try:
-            lines = pathlib.Path(self.template).read_text().splitlines()
-            job_xml_tree = fromstring(do_xml_replacements(lines,
-                                                          {'KVER': release,
-                                                           'KPKG_URL': url,
-                                                           'ARCH': arch}))
+            text = pathlib.Path(self.template).read_text()
+            job_xml_tree = fromstring(text)
             # add blacklist to all recipes
             self.add_blacklist2recipes(job_xml_tree)
 

--- a/tests/assets/test.xml
+++ b/tests/assets/test.xml
@@ -1,18 +1,18 @@
 <job>
-  <whiteboard>skt ##KVER## [noavc] [noselinux]</whiteboard>
+  <whiteboard>skt 3.10.xx [noavc] [noselinux]</whiteboard>
   <recipeSet>
-    <recipe ks_meta="harness='restraint-rhts beakerlib-redhat'" kernel_options="selinux=0" whiteboard="##KVER##">
+    <recipe ks_meta="harness='restraint-rhts beakerlib-redhat'" kernel_options="selinux=0" whiteboard="3.10.xx">
       <distroRequires>
         <and>
           <distro_family op="=" value="Fedora26"/>
           <distro_tag op="=" value="RELEASED"/>
           <distro_variant op="=" value="Server"/>
-          <distro_arch op="=" value="##ARCH##"/>
+          <distro_arch op="=" value="x86_64"/>
         </and>
       </distroRequires>
       <hostRequires>
         <and>
-          <arch op="=" value="##ARCH##"/>
+          <arch op="=" value="x86_64"/>
         </and>
       </hostRequires>
       <repos/>
@@ -33,7 +33,7 @@
         <fetch url="https://github.com/RH-FMK/tests-beaker.git?master#distribution/kpkginstall"/>
         <params>
           <param name="KPKG_URL" value="##KPKG_URL##"/>
-          <param name="KVER" value="##KVER##"/>
+          <param name="KVER" value="3.10.xx"/>
         </params>
       </task>
     </recipe>

--- a/tests/misc.py
+++ b/tests/misc.py
@@ -22,6 +22,9 @@ SCRIPT_PATH = os.path.dirname(__file__)
 DEFAULT_ARGS = {
     'jobtemplate': '{}/assets/test.xml'.format(SCRIPT_PATH)
 }
+INV_TEMPLATE_ARGS = {
+    'jobtemplate': '{}/assets/0.xml'.format(SCRIPT_PATH)
+}
 
 
 def get_asset_path(filename):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -377,17 +377,15 @@ class TestRunner(unittest.TestCase):
         self.assertEqual(result, 0)
 
     @mock.patch('logging.error')
-    @mock.patch('skt.runner.do_xml_replacements')
-    def test_run_fail(self, mock_logging_err, mock_getxml):
+    def test_run_fail(self, mock_logging_err):
         """Ensure BeakerRunner.run errors on invalid xml."""
         # pylint: disable=W0613
         url = "http://machine1.example.com/builds/1234567890.tar.gz"
         release = "4.17.0-rc1"
         wait = True
+        inv_runner = runner.BeakerRunner(**misc.INV_TEMPLATE_ARGS)
 
-        mock_getxml.return_value = '<xml >'
-
-        result = self.myrunner.run(url, self.max_aborted, release, wait)
+        result = inv_runner.run(url, self.max_aborted, release, wait)
         self.assertEqual(result, 2)
 
     @mock.patch('skt.runner.BeakerRunner.getresultstree')


### PR DESCRIPTION
We don't replace vars in skt anymore. kpet handles all of those vars, so
beaker.xml is no longer really a template file.

Signed-off-by: Jakub Racek <jracek@redhat.com>